### PR TITLE
fix for exec not working with pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ docs = [
 ]
 
 [project.scripts]
-CodeEntropy = "main_mcc:main"
+CodeEntropy = "CodeEntropy.main_mcc:main"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
### Summary
CodeEntropy executable received the wrong call path from the pyproject.toml. Can either update the CodeEntropy package to autoimport or modify pyproject.toml to point to the correct module. The former brings linter warnings to disable about unused imports so the latter option was chosen here.

### Changes
Fix pyproject.toml:
- Change the script exec line to reflect module structure.

### Impact
- Expected to be minor impact since it is in the setup script. This will fix the need to modify the auto created executable upon installation.