### PR TITLE
Weighted Torque Bug

### DIFF
--- a/CodeEntropy/GeometricFunctions.py
+++ b/CodeEntropy/GeometricFunctions.py
@@ -304,6 +304,9 @@ def get_weighted_torques(data_container, bead, rot_axes, force_partitioning=0.5)
     (since values below machine precision are effectively zero). This avoids
     unnecessary use of extended precision (e.g., float128).
 
+    Additionally, if the computed torque is already zero, the function skips
+    the division step, reducing unnecessary computations and potential errors.
+
     Parameters
     ----------
     data_container : object
@@ -348,6 +351,11 @@ def get_weighted_torques(data_container, bead, rot_axes, force_partitioning=0.5)
     moment_of_inertia = bead.moment_of_inertia()
 
     for dimension in range(3):
+        # Skip calculation if torque is already zero
+        if np.isclose(torques[dimension], 0):
+            weighted_torque[dimension] = 0
+            continue
+
         if np.isclose(moment_of_inertia[dimension, dimension], 0):
             weighted_torque[dimension] = torques[dimension]
         else:

--- a/CodeEntropy/GeometricFunctions.py
+++ b/CodeEntropy/GeometricFunctions.py
@@ -298,15 +298,27 @@ def get_weighted_torques(data_container, bead, rot_axes, force_partitioning=0.5)
     """
     Function to calculate the moment of inertia weighted torques for a given bead.
 
-    Input
-    -----
-    bead : the part of the molecule to be considered
-    rot_axes : the axes relative to which the forces and coordinates are located
-    frame : the frame number from the trajectory
+    This function computes torques in a rotated frame and then weights them using
+    the moment of inertia tensor. To prevent numerical instability, it treats
+    extremely small diagonal elements of the moment of inertia tensor as zero
+    (since values below machine precision are effectively zero). This avoids
+    unnecessary use of extended precision (e.g., float128).
 
-    Output
-    ------
-    weighted_torque : the mass weighted sum of the torques in the bead
+    Parameters
+    ----------
+    data_container : object
+        Contains atomic positions and forces.
+    bead : object
+        The part of the molecule to be considered.
+    rot_axes : np.ndarray
+        The axes relative to which the forces and coordinates are located.
+    force_partitioning : float, optional
+        Factor to adjust force contributions, default is 0.5.
+
+    Returns
+    -------
+    np.ndarray
+        The mass-weighted sum of the torques in the bead.
     """
 
     torques = np.zeros((3,))
@@ -336,17 +348,18 @@ def get_weighted_torques(data_container, bead, rot_axes, force_partitioning=0.5)
     moment_of_inertia = bead.moment_of_inertia()
 
     for dimension in range(3):
-        # Check if the moment of inertia is valid for square root calculation
-        inertia_value = moment_of_inertia[dimension, dimension]
-
-        if np.isclose(inertia_value, 0):
-            raise ValueError(
-                f"Invalid moment of inertia value: {inertia_value}. "
-                f"Cannot compute weighted torque."
+        if np.isclose(moment_of_inertia[dimension, dimension], 0):
+            weighted_torque[dimension] = torques[dimension]
+        else:
+            if moment_of_inertia[dimension, dimension] < 0:
+                raise ValueError(
+                    f"Negative value encountered for moment of inertia: "
+                    f"{moment_of_inertia[dimension, dimension]} "
+                    f"Cannot compute weighted torque."
+                )
+            weighted_torque[dimension] = torques[dimension] / np.sqrt(
+                moment_of_inertia[dimension, dimension]
             )
-
-        # compute weighted torque if moment of inertia is valid
-        weighted_torque[dimension] = torques[dimension] / np.sqrt(inertia_value)
 
     return weighted_torque
 

--- a/CodeEntropy/GeometricFunctions.py
+++ b/CodeEntropy/GeometricFunctions.py
@@ -356,18 +356,25 @@ def get_weighted_torques(data_container, bead, rot_axes, force_partitioning=0.5)
             weighted_torque[dimension] = 0
             continue
 
+        # Check for zero moment of inertia
         if np.isclose(moment_of_inertia[dimension, dimension], 0):
-            weighted_torque[dimension] = torques[dimension]
-        else:
-            if moment_of_inertia[dimension, dimension] < 0:
-                raise ValueError(
-                    f"Negative value encountered for moment of inertia: "
-                    f"{moment_of_inertia[dimension, dimension]} "
-                    f"Cannot compute weighted torque."
-                )
-            weighted_torque[dimension] = torques[dimension] / np.sqrt(
-                moment_of_inertia[dimension, dimension]
+            raise ZeroDivisionError(
+                f"Attempted to divide by zero moment of inertia in dimension "
+                f"{dimension}."
             )
+
+        # Check for negative moment of inertia
+        if moment_of_inertia[dimension, dimension] < 0:
+            raise ValueError(
+                f"Negative value encountered for moment of inertia: "
+                f"{moment_of_inertia[dimension, dimension]} "
+                f"Cannot compute weighted torque."
+            )
+
+        # Compute weighted torque
+        weighted_torque[dimension] = torques[dimension] / np.sqrt(
+            moment_of_inertia[dimension, dimension]
+        )
 
     return weighted_torque
 


### PR DESCRIPTION
### Summary
<!-- Provide a brief description of the PR's purpose here. -->
This PR addresses issues related to the weighted torque calculation by reverting to the original method, optimizing the calculation to prevent crashes, and improving documentation for clarity.

### Changes
<!-- List all the changes introduced in this PR. -->
Revert weighted torque calculation and improve documentation: 
- Restored the original method for computing weighted torque.
-  Clarified handling of small moment of inertia values in the docstring, explaining why values below machine precision are treated as zero.
- Also included a ValueError check guard on the square root calculation to make sure that the square root does not have any negative numbers within it.
- No functional changes beyond reverting to the previous calculation method.

Optimize weighted torque calculation to reduce crashes:
- Added a check to skip the calculation if the torque is already zero, as highlighted in issue #55, reducing unnecessary calculations.
- Retained the divide-by-zero check to ensure numerical stability when computing weighted torques.
- Improved docstring to reflect the updated logic.

### Impact
- The reverted method restores the original weighted torque calculation, which maintains the standards that were followed in previous versions of the code but with an explanation as to why this is being calculated this way.
- The optimization prevents unnecessary calculations when the torque is zero, potentially improving performance and preventing crashes in certain scenarios.
- The improved documentation provides better clarity on the treatment of small moment of inertia values and the updated logic for weighted torque calculations.