### PR TITLE
Resolve issue #68 where there was a mismatch in the args naming convention

### DIFF
--- a/CodeEntropy/main_mcc.py
+++ b/CodeEntropy/main_mcc.py
@@ -46,7 +46,7 @@ arg_map = {
         "help": "Bin width in degrees for making the histogram",
         "default": 30,
     },
-    "tempra": {
+    "temperature": {
         "type": float,
         "help": "Temperature for entropy calculation (K)",
         "default": 298.0,
@@ -286,7 +286,7 @@ def main():
 
                     # Calculate the entropy from the diagonalisation of the matrices
                     S_trans_residue = EF.vibrational_entropy(
-                        force_matrix, "force", args.tempra, highest_level
+                        force_matrix, "force", args.temperature, highest_level
                     )
                     S_trans += S_trans_residue
                     print(f"S_trans_{level}_{residue} = {S_trans_residue}")
@@ -312,7 +312,7 @@ def main():
                         )
 
                     S_rot_residue = EF.vibrational_entropy(
-                        torque_matrix, "torque", args.tempra, highest_level
+                        torque_matrix, "torque", args.temperature, highest_level
                     )
                     S_rot += S_rot_residue
                     print(f"S_rot_{level}_{residue} = {S_rot_residue}")
@@ -438,7 +438,7 @@ def main():
 
                 # Calculate the entropy from the diagonalisation of the matrices
                 S_trans = EF.vibrational_entropy(
-                    force_matrix, "force", args.tempra, highest_level
+                    force_matrix, "force", args.temperature, highest_level
                 )
                 print(f"S_trans_{level} = {S_trans}")
                 new_row = pd.DataFrame(
@@ -456,7 +456,7 @@ def main():
                     )
 
                 S_rot = EF.vibrational_entropy(
-                    torque_matrix, "torque", args.tempra, highest_level
+                    torque_matrix, "torque", args.temperature, highest_level
                 )
                 print(f"S_rot_{level} = {S_rot}")
                 new_row = pd.DataFrame(

--- a/CodeEntropy/main_mcc.py
+++ b/CodeEntropy/main_mcc.py
@@ -286,7 +286,7 @@ def main():
 
                     # Calculate the entropy from the diagonalisation of the matrices
                     S_trans_residue = EF.vibrational_entropy(
-                        force_matrix, "force", args.temp, highest_level
+                        force_matrix, "force", args.tempra, highest_level
                     )
                     S_trans += S_trans_residue
                     print(f"S_trans_{level}_{residue} = {S_trans_residue}")
@@ -312,7 +312,7 @@ def main():
                         )
 
                     S_rot_residue = EF.vibrational_entropy(
-                        torque_matrix, "torque", args.temp, highest_level
+                        torque_matrix, "torque", args.tempra, highest_level
                     )
                     S_rot += S_rot_residue
                     print(f"S_rot_{level}_{residue} = {S_rot_residue}")
@@ -438,7 +438,7 @@ def main():
 
                 # Calculate the entropy from the diagonalisation of the matrices
                 S_trans = EF.vibrational_entropy(
-                    force_matrix, "force", args.temp, highest_level
+                    force_matrix, "force", args.tempra, highest_level
                 )
                 print(f"S_trans_{level} = {S_trans}")
                 new_row = pd.DataFrame(
@@ -456,7 +456,7 @@ def main():
                     )
 
                 S_rot = EF.vibrational_entropy(
-                    torque_matrix, "torque", args.temp, highest_level
+                    torque_matrix, "torque", args.tempra, highest_level
                 )
                 print(f"S_rot_{level} = {S_rot}")
                 new_row = pd.DataFrame(


### PR DESCRIPTION
### Summary
<!-- Provide a brief description of the PR's purpose here. -->
This PR resolves an issue whereby the naming convention on the new argument handler didn't correctly have the correct association, which resulted in a crash in the program as it was not in the `arg_map` dictionary.

### Changes
<!-- List all the changes introduced in this PR. -->
Re-named variables: <!-- Rename Change 1 to reflect change title -->:
- Changed all instances of `args.temp` to `args.temperature`

### Impact
- This will now allow calculations within CodeEntropy to run as expected and not result in a crash when it comes across the `args.temp` declaration