### PR TITLE
Issue 63- Conformational Entropy Calculation 

### DIFF
--- a/CodeEntropy/LevelFunctions.py
+++ b/CodeEntropy/LevelFunctions.py
@@ -181,9 +181,7 @@ def get_dihedrals(data_container, level):
 
     # if united atom level, read dihedrals from MDAnalysis universe
     if level == "united_atom":
-        # only use dihedrals made of heavy atoms
-        heavy_atom_group = data_container.select_atoms("not name H*")
-        dihedrals = heavy_atom_group.dihedrals
+        dihedrals = data_container.dihedrals
 
     # if residue level, looking for dihedrals involving residues
     if level == "residue":

--- a/CodeEntropy/main_mcc.py
+++ b/CodeEntropy/main_mcc.py
@@ -308,6 +308,7 @@ def main():
                 S_trans = 0
                 S_rot = 0
                 S_conf = 0
+
                 for residue in range(num_residues):
                     # molecule data container of MDAnalysis Universe type for internal
                     # degrees of freedom getting indices of first and last atoms in the
@@ -319,10 +320,14 @@ def main():
                     residue_container = MDAHelper.new_U_select_atom(
                         molecule_container, selection_string
                     )
+                    residue_heavy_atoms_container = MDAHelper.new_U_select_atom(
+                        residue_container, "not name H*"
+                    )  # only heavy atom dihedrals are relevant
 
                     # Vibrational entropy at every level
                     # Get the force and torque matrices for the beads at the relevant
                     # level
+
                     force_matrix, torque_matrix = LF.get_matrices(
                         residue_container,
                         level,
@@ -392,11 +397,11 @@ def main():
                     # Gives entropy of conformations within each residue
 
                     # Get dihedral angle distribution
-                    dihedrals = LF.get_dihedrals(residue_container, level)
+                    dihedrals = LF.get_dihedrals(residue_heavy_atoms_container, level)
 
                     # Calculate conformational entropy
                     S_conf_residue = EF.conformational_entropy(
-                        residue_container,
+                        residue_heavy_atoms_container,
                         dihedrals,
                         bin_width,
                         start,


### PR DESCRIPTION
### Summary
This PR addresses issues related to the calculation of the conformational entropy at the united atom and residue levels and resolves the differences between results obtained using the current implementation of the theory at the united atom level and the implementation from the previous release. Differences for each type of residue, prior the commit, with terminal residues being isolated, are shown in the figure below. This PR closes #63 
![conformational_entropy_per_residue](https://github.com/user-attachments/assets/2633d0e0-6d05-4d9a-8038-1064df708ff7)


### Changes
<!-- List all the changes introduced in this PR. -->
Heavy atoms universe <!-- Rename Change 1 to reflect change title -->:
-  A new MDAnalysis universe is created, containing only the heavy atoms in a residue and this universe now represents the data_container argument for the get_dihedrals and conformational_entropy functions. Previously, the functions called an MDAnalysis universe containing all atoms within a residue and iterated 
per heavy atom in residue - hence, all dihedrals that the heavy atoms were involved in were found and taken into account. 
  

### Impact

-  Heavy atom-only dihedrals are now identified and taken into account for the conformational entropy calculation. Values obtained for aliphatic residues now match values obtained using the previous AEM implementation, as shown in the figure below. 
![Sconf_per_residue_post_first_commit](https://github.com/user-attachments/assets/8b9fe62e-1125-4604-9d57-365eeadfd037)

![Sconf_per_residue](https://github.com/user-attachments/assets/c0fa4018-3f04-47d5-97f0-5f51b3e3028f)


- In the previous implementation, terminal residues each had an additional dihedral, as shown in the figure below. These dihedrals coincide with backbone dihedrals, which are now accounted for by the residue level calculation.
<img width="645" alt="terminal_residue_dihedrals" src="https://github.com/user-attachments/assets/cf0349a2-17bc-450e-a40f-367feaa3750e" />

- Previous implementation seems to sometimes double count some turning points for aromatic side chains that are rigid, as seen in the figure below for a phenylalanine. However, the aromatic rings are flipped as a result of the rotation about a different bond, not as a result of these dihedral adopting a new conformation so these conformations shouldn't be taken into account. Therefore, entropy of residues with aromatic side chains was much higher sometimes - this should be fine in the current new implementation and explains the difference observed for aromatic side chains.
<img width="622" alt="old_aromatic_conformational_entropy_issue" src="https://github.com/user-attachments/assets/f18ee3ba-77a4-431d-b37d-75e0f2499137" />


### Possible future considerations 
-  Currently, the backbone entropy is estimated using the residue level calculation, which treats a whole residue as a bead and takes into account dihedrals consisting of four neighbouring residues. Backbone entropy could also be calculated using the phi and psi dihedrals, obtained using the corresponding MDAnalysis functions (https://userguide.mdanalysis.org/1.1.1/examples/analysis/structure/dihedrals.html). Results seem to be very close anyway.
<img width="301" alt="Sconf_residue_level" src="https://github.com/user-attachments/assets/17846dfd-590a-4ac6-ae39-8245a7e1cbcf" />

