### PR TITLE
Fix Argument Precedence

### DIFF
--- a/CodeEntropy/config/arg_config_manager.py
+++ b/CodeEntropy/config/arg_config_manager.py
@@ -116,7 +116,7 @@ class ConfigManager:
         # Step 1: Apply YAML values if CLI didn't explicitly set the argument
         for key, yaml_value in run_config.items():
             if yaml_value is not None and key not in cli_provided_args:
-                logger.info(f"Using YAML value for {key}: {yaml_value}")
+                logger.debug(f"Using YAML value for {key}: {yaml_value}")
                 setattr(args, key, yaml_value)
 
         # Step 2: Ensure all arguments have at least their default values

--- a/CodeEntropy/config/arg_config_manager.py
+++ b/CodeEntropy/config/arg_config_manager.py
@@ -101,19 +101,32 @@ class ConfigManager:
         if not isinstance(run_config, dict):
             raise TypeError("run_config must be a dictionary or None.")
 
-        # Step 1: Merge YAML configuration into args
-        for key, value in run_config.items():
-            if getattr(args, key, None) is None:
-                setattr(args, key, value)
+        # Convert argparse Namespace to dictionary
+        args_dict = vars(args)
 
-        # Step 2: Set default values for any missing arguments from `arg_map`
+        # Reconstruct parser and check which arguments were explicitly provided via CLI
+        parser = self.setup_argparse()
+        default_args = parser.parse_args([])
+        default_dict = vars(default_args)
+
+        cli_provided_args = {
+            key for key, value in args_dict.items() if value != default_dict.get(key)
+        }
+
+        # Step 1: Apply YAML values if CLI didn't explicitly set the argument
+        for key, yaml_value in run_config.items():
+            if yaml_value is not None and key not in cli_provided_args:
+                logger.info(f"Using YAML value for {key}: {yaml_value}")
+                setattr(args, key, yaml_value)
+
+        # Step 2: Ensure all arguments have at least their default values
         for key, params in self.arg_map.items():
             if getattr(args, key, None) is None:
                 setattr(args, key, params.get("default"))
 
-        # Step 3: Override with CLI values if provided
+        # Step 3: Ensure CLI arguments always take precedence
         for key in self.arg_map.keys():
-            cli_value = getattr(args, key, None)
+            cli_value = args_dict.get(key)
             if cli_value is not None:
                 run_config[key] = cli_value
 


### PR DESCRIPTION
### Summary
<!-- Provide a brief description of the PR's purpose here. -->
In this PR, the argument merging logic is fixed to ensure the correct precedence: CLI > YAML > Defaults. Previously, YAML values were sometimes ignored due to argparse defaults being mistakenly treated as explicit CLI inputs. This PR ensures that CLI arguments take priority, YAML fills in missing values, and defaults are used only as a last resort.

### Changes
<!-- List all the changes introduced in this PR. -->
Fix argument precedence handling:
- Compare CLI arguments against argparse’s default values `parse_args([])` to correctly detect which values were explicitly set by the user.
- Apply YAML values only if the CLI has not explicitly overridden them.
- Ensure default values are only used when both CLI and YAML are absent.

Improve merging logic in `merge_configs()`:
- Prevent YAML values from being ignored when CLI inputs are not explicitly provided.
- Maintain correct priority order: CLI > YAML > Defaults.

Enhance logging for debugging:
- Log when values are being overridden by CLI or YAML.
- Improve debugging output to track final argument values after merging.  

### Impact
- Ensures CLI arguments always take priority over YAML and default values.
- Fixes cases where YAML inputs were incorrectly ignored.
- Improves reliability of configuration handling.
- Provides better logging for debugging configuration issues.