### PR TITLE
Resolve issue #80 fixing indexing issue for start parameter affecting timesteps

### DIFF
--- a/CodeEntropy/calculations/ConformationFunctions.py
+++ b/CodeEntropy/calculations/ConformationFunctions.py
@@ -38,13 +38,14 @@ def assign_conformation(
     # get the values of the angle for the dihedral
     # dihedral angle values have a range from -180 to 180
     for timestep in data_container.trajectory[start:end:step]:
+        timestep_index = timestep.frame - start
         value = dihedral.value()
         # we want postive values in range 0 to 360 to make the peak assignment work
         # using the fact that dihedrals have circular symetry
         # (i.e. -15 degrees = +345 degrees)
         if value < 0:
             value += 360
-        phi[timestep.frame] = value
+        phi[timestep_index] = value
 
     # create a histogram using numpy
     number_bins = int(360 / bin_width)

--- a/CodeEntropy/calculations/LevelFunctions.py
+++ b/CodeEntropy/calculations/LevelFunctions.py
@@ -94,10 +94,11 @@ def get_matrices(
             trans_axes, rot_axes = GF.get_axes(data_container, level, bead_index)
 
             # Sort out coordinates, forces, and torques for each atom in the bead
-            weighted_forces[bead_index][timestep.frame] = GF.get_weighted_forces(
+            timestep_index = timestep.frame - start
+            weighted_forces[bead_index][timestep_index] = GF.get_weighted_forces(
                 data_container, list_of_beads[bead_index], trans_axes, highest_level
             )
-            weighted_torques[bead_index][timestep.frame] = GF.get_weighted_torques(
+            weighted_torques[bead_index][timestep_index] = GF.get_weighted_torques(
                 data_container, list_of_beads[bead_index], rot_axes
             )
 


### PR DESCRIPTION
### Summary
This PR is to fix an index issue that caused out of bounds errors when the start parameter for selecting a subset of frames from the trajectory was not zero.

### Changes
In the get_matrices and assign_conformation functions where the code was looping over timesteps, changed from using timestep.frame to using an index that counts from the first timestep used rather than the frame number in the original trajectory (timestep_index = timestep.frame - start).

### Impact
- Reduces the number of IndexErrors raised