### PR TITLE
Fixing an off by one indexing error when slicing trajectories.

### DIFF
--- a/CodeEntropy/config/arg_config_manager.py
+++ b/CodeEntropy/config/arg_config_manager.py
@@ -25,7 +25,10 @@ arg_map = {
     },
     "end": {
         "type": int,
-        "help": "Stop analysing the trajectory at this frame index. This is the frame index of the last frame to be included, so for example if start=0 and end=500 there would be 501 frames analysed. The default -1 will include everything up to the last frame.",
+        "help": ("Stop analysing the trajectory at this frame index. This is "
+                 "the frame index of the last frame to be included, so for example"
+                 "if start=0 and end=500 there would be 501 frames analysed. The "
+                 "default -1 will include everything up to the last frame."),
         "default": -1,
     },
     "step": {

--- a/CodeEntropy/config/arg_config_manager.py
+++ b/CodeEntropy/config/arg_config_manager.py
@@ -25,10 +25,11 @@ arg_map = {
     },
     "end": {
         "type": int,
-        "help": ("Stop analysing the trajectory at this frame index. This is "
-                 "the frame index of the last frame to be included, so for example"
-                 "if start=0 and end=500 there would be 501 frames analysed. The "
-                 "default -1 will include everything up to the last frame."
+        "help": (
+            "Stop analysing the trajectory at this frame index. This is "
+            "the frame index of the last frame to be included, so for example"
+            "if start=0 and end=500 there would be 501 frames analysed. The "
+            "default -1 will include the last frame."
         ),
         "default": -1,
     },

--- a/CodeEntropy/config/arg_config_manager.py
+++ b/CodeEntropy/config/arg_config_manager.py
@@ -29,7 +29,7 @@ arg_map = {
                  "the frame index of the last frame to be included, so for example"
                  "if start=0 and end=500 there would be 501 frames analysed. The "
                  "default -1 will include everything up to the last frame."
-                 ),
+        ),
         "default": -1,
     },
     "step": {

--- a/CodeEntropy/config/arg_config_manager.py
+++ b/CodeEntropy/config/arg_config_manager.py
@@ -25,7 +25,7 @@ arg_map = {
     },
     "end": {
         "type": int,
-        "help": "Stop analysing the trajectory at this frame index",
+        "help": "Stop analysing the trajectory at this frame index. This is the frame index of the last frame to be included, so for example if start=0 and end=500 there would be 501 frames analysed. The default -1 will include everything up to the last frame.",
         "default": -1,
     },
     "step": {

--- a/CodeEntropy/config/arg_config_manager.py
+++ b/CodeEntropy/config/arg_config_manager.py
@@ -28,7 +28,8 @@ arg_map = {
         "help": ("Stop analysing the trajectory at this frame index. This is "
                  "the frame index of the last frame to be included, so for example"
                  "if start=0 and end=500 there would be 501 frames analysed. The "
-                 "default -1 will include everything up to the last frame."),
+                 "default -1 will include everything up to the last frame."
+                 ),
         "default": -1,
     },
     "step": {

--- a/CodeEntropy/main_mcc.py
+++ b/CodeEntropy/main_mcc.py
@@ -127,13 +127,17 @@ def main():
     if step is None:
         step = 1
     # Count number of frames, easy if not slicing
+    # MDAnalysis trajectory slicing only includes up to end-1
+    # This works the way we want it to if the whole trajectory is being included
     if start == 0 and end == -1 and step == 1:
+        end = len(u.trajectory)
         number_frames = len(u.trajectory)
     elif end == -1:
         end = len(u.trajectory)
-        number_frames = math.floor((end - start) / step) + 1
+        number_frames = math.floor((end - start) / step) 
     else:
-        number_frames = math.floor((end - start) / step) + 1
+        end = end + 1
+        number_frames = math.floor((end - start) / step)
     logger.debug(f"Number of Frames: {number_frames}")
 
     # Create pandas data frame for results

--- a/CodeEntropy/main_mcc.py
+++ b/CodeEntropy/main_mcc.py
@@ -134,7 +134,7 @@ def main():
         number_frames = len(u.trajectory)
     elif end == -1:
         end = len(u.trajectory)
-        number_frames = math.floor((end - start) / step) 
+        number_frames = math.floor((end - start) / step)
     else:
         end = end + 1
         number_frames = math.floor((end - start) / step)


### PR DESCRIPTION
### Summary
This is to fix errors when the slicing of trajectories occurs (MDAnalysis uses the end variable and then goes to frame end-1).

### Changes
Adapting the end parameter to account for the whole trajectory as the default, but to give the expected frames and frame count when end is set to a positive integer.

### Impact
This should give the correct results. In particular, it will avoid the problem of the dihedral angle appearing as 0 when there was a mismatch between the frames MDAnalysis included in the timesteps loop and the expected number of frames reducing the number of incorrect peaks in the histograms for the conformational entropy.