### PR TITLE
Extention to CI capabilities with comparisions between CodeEntropy and MDAnalysis

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -68,3 +68,34 @@ jobs:
      run: |
        pre-commit install
        pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
+
+  mdanalysis_compatibility:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+        mdanalysis-version: ["2.7.0", "2.8.0", "2.9.0", "latest"]
+    name: MDAnalysis v${{ matrix.mdanalysis-version }} / Python ${{ matrix.python-version }}
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies with MDAnalysis ${{ matrix.mdanalysis-version }}
+      run: |
+        pip install --upgrade pip
+        if [ "${{ matrix.mdanalysis-version }}" = "latest" ]; then
+          pip install -e .[testing]
+          pip install MDAnalysis
+        else
+          pip install -e .[testing]
+          pip install "MDAnalysis==${{ matrix.mdanalysis-version }}"
+        fi
+
+    - name: Run tests
+      run: pytest --cov CodeEntropy --cov-report=term-missing --cov-append


### PR DESCRIPTION
### Summary
This PR enhances the CI pipeline by adding automated compatibility checks between `CodeEntropy` and multiple versions of `MDAnalysis`. The goal is to detect and address breaking changes introduced in new `MDAnalysis` releases early in the development cycle.

### Changes
- Added a new matrix job in `ci.yaml` to test `CodeEntropy` against:
  - Python 3.11, 3.12 and 3.13
  - MDAnalysis versions: 2.7.0, 2.8.0, 2.9.0, and `latest`
- Installs pinned versions of `MDAnalysis` dynamically during CI runs
- Executes the test suite for each version combination

### Impact
- Ensures continued compatibility between `CodeEntropy` and evolving `MDAnalysis` versions
- Improves reliability and trust in future releases