### PR TITLE
Fix Coveralls CI failure on Dependabot PRs by using `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/project-ci.yaml
+++ b/.github/workflows/project-ci.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Coveralls GitHub Action
         uses: coverallsapp/github-action@v2.3.6
         with:
-          github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Summary
Switch Coveralls token from `COVERALLS_REPO_TOKEN` to `GITHUB_TOKEN` to fix CI failures on Dependabot PRs for `CodeEntropy` as this is a public repo.

### Changes
**Change 1: Update Coveralls GitHub Action step**
- Replaced `secrets.COVERALLS_REPO_TOKEN` with `secrets.GITHUB_TOKEN` in `project-ci.yaml`
- This enables Dependabot PRs to pass CI by using a token that is available to them

### Impact
- Dependabot PRs will no longer fail due to missing Coveralls repo token
- CI coverage uploads will continue to work for all PRs and branches