### PR TITLE
MDAnalysis File Location Bug

### DIFF
--- a/.github/workflows/project-ci.yaml
+++ b/.github/workflows/project-ci.yaml
@@ -110,6 +110,6 @@ jobs:
           RUN_NUMBER: ${{ github.run_number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
-          filename: .github/mdanalysis-compatibility-failure.md
+          filename: .github/workflows/mdanalysis-compatibility-failure.md
           update_existing: true
           search_existing: open


### PR DESCRIPTION
### Summary
This PR ensures that the `mdanalysis-compatibility-failure.md` within the github workflows is called from the right location within the `project-ci.yaml`.

### Changes
<!-- List all the changes introduced in this PR. -->
Change file location within `project-ci.yaml`:
- Changed the file location from `.github/mdanalysis-compatibility-failure.md` to `.github/workflows/mdanalysis-compatibility-failure.md`.

### Impact
- This will ensure there is greater understanding when trying to debug errors from the GitHub Actions CI runs.