### PR TITLE
Enforcing `MDAnalysis` versions `2.9` and Above

### DIFF
--- a/.github/workflows/project-ci.yaml
+++ b/.github/workflows/project-ci.yaml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
-        mdanalysis-version: ["2.7.0", "2.8.0", "2.9.0", "latest"]
+        mdanalysis-version: ["2.9.0", "latest"]
     name: MDAnalysis Compatibility Tests
     steps:
       - name: Checkout repo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ keywords = ["entropy", "macromolecular systems", "MD simulation"]
 requires-python = ">=3.11"
 dependencies = [
     "numpy==2.2.3",
-    "mdanalysis>=2.7.0",
+    "mdanalysis>=2.9.0",
     "pandas==2.2.3",
     "psutil==5.9.5",
     "PyYAML==6.0.2",


### PR DESCRIPTION
### Summary
This PR will reflect the issues raised in issue #118, and will ensure that there are no compatability issues with previous versions of `MDAnalysis` and `CodeEntropy`

### Changes
<!-- List all the changes introduced in this PR. -->
Upgraded versions of `MDAnalysis`:
- Enforced the use of `MDAnalysis` versions greater than `v2.9` within `pyproject.toml`
- Removed the old versions of `MDAnalysis` from the `mdanalysis-compatibility` test run within the `project-ci.yaml`

### Impact
- This will resolve the issues highlighted in #118 
- This will also ensure that users are using the latest versions of `MDAnalysis` with `CodeEntropy` which will therefore mean they have the most up to date features possible