### PR TITLE
Refactor entropy calculation: switch to per-timestep computation with molecule-type averaging

### DIFF
--- a/CodeEntropy/config/arg_config_manager.py
+++ b/CodeEntropy/config/arg_config_manager.py
@@ -64,6 +64,11 @@ arg_map = {
         "help": "If set to False, disables the calculation of water entropy",
         "default": True,
     },
+    "grouping": {
+        "type": str,
+        "help": "How to group molecules for averaging",
+        "default": "each",
+    },
 }
 
 

--- a/CodeEntropy/entropy.py
+++ b/CodeEntropy/entropy.py
@@ -211,7 +211,6 @@ class EntropyManager:
                     self._process_united_atom_entropy(
                         mol_id,
                         mol,
-                        res_id,
                         ve,
                         ce,
                         level,
@@ -329,7 +328,6 @@ class EntropyManager:
         self,
         mol_id,
         mol_container,
-        res_id,
         ve,
         ce,
         level,

--- a/CodeEntropy/entropy.py
+++ b/CodeEntropy/entropy.py
@@ -748,7 +748,7 @@ class ConformationalEntropy(EntropyManager):
 
         # get the values of the angle for the dihedral
         # dihedral angle values have a range from -180 to 180
-        for timestep in data_container.trajectory[start : end + 1 : step]:
+        for timestep in data_container.trajectory[start:end:step]:
             timestep_index = timestep.frame - start
             value = dihedral.value()
             # we want postive values in range 0 to 360 to make the peak assignment

--- a/CodeEntropy/entropy.py
+++ b/CodeEntropy/entropy.py
@@ -201,14 +201,15 @@ class EntropyManager:
                                 step,
                             )
                             dihedral_index += 1
-                        
+
                         # concatenate conformations into state string
                         states_ua[key] = ["" for x in range(number_frames)]
                         for frame_index in range(number_frames):
                             for dihedral_index in range(num_dihedrals):
-                                states_ua[key][frame_index] += str(conformation[dihedral_index][frame_index])
+                                states_ua[key][frame_index] += str(
+                                    conformation[dihedral_index][frame_index]
+                                )
                         logger.debug(f"States UA {states_ua[key]}")
-
 
                     # Calculate the united atom entropy
                     self._process_united_atom_entropy(
@@ -250,9 +251,10 @@ class EntropyManager:
                     states_res = ["" for x in range(number_frames)]
                     for frame_index in range(number_frames):
                         for dihedral_index in range(num_dihedrals):
-                            states_res[frame_index] += str(conformation[dihedral_index][frame_index])
+                            states_res[frame_index] += str(
+                                conformation[dihedral_index][frame_index]
+                            )
                     logger.debug(f"States UA {states_res}")
-
 
                     self._process_vibrational_entropy(
                         molecule_id,
@@ -454,10 +456,10 @@ class EntropyManager:
             level.
         """
         number_frames = len(mol_container.trajectory)
-        
+
         force_matrix = self._level_manager.filter_zero_rows_columns(force_matrix)
         force_matrix = force_matrix / number_frames
-        
+
         torque_matrix = self._level_manager.filter_zero_rows_columns(torque_matrix)
         torque_matrix = torque_matrix / number_frames
 

--- a/CodeEntropy/entropy.py
+++ b/CodeEntropy/entropy.py
@@ -16,7 +16,9 @@ class EntropyManager:
     molecular dynamics trajectory.
     """
 
-    def __init__(self, run_manager, args, universe, data_logger, level_manager, group_molecules):
+    def __init__(
+        self, run_manager, args, universe, data_logger, level_manager, group_molecules
+    ):
         """
         Initializes the EntropyManager with required components.
 
@@ -67,36 +69,31 @@ class EntropyManager:
 
         self._handle_water_entropy(start, end, step)
         reduced_atom, number_molecules, levels, groups = self._initialize_molecules()
-        number_groups = len(groups)
         number_frames = len(reduced_atom.trajectory)
 
-        force_matrices, torque_matrices = (
-            self._level_manager.build_covariance_matrices(
-                self,
-                reduced_atom,
-                levels,
-                groups,
-                start,
-                end,
-                step,
-                number_frames,
-            )
+        force_matrices, torque_matrices = self._level_manager.build_covariance_matrices(
+            self,
+            reduced_atom,
+            levels,
+            groups,
+            start,
+            end,
+            step,
+            number_frames,
         )
 
-        states_ua, states_res = (
-            self._level_manager.build_conformational_states(
-                self,
-                reduced_atom,
-                number_molecules,
-                levels,
-                groups,
-                start,
-                end,
-                step,
-                number_frames,
-                self._args.bin_width,
-                ce,
-            )
+        states_ua, states_res = self._level_manager.build_conformational_states(
+            self,
+            reduced_atom,
+            number_molecules,
+            levels,
+            groups,
+            start,
+            end,
+            step,
+            number_frames,
+            self._args.bin_width,
+            ce,
         )
 
         self._compute_entropies(
@@ -379,15 +376,9 @@ class EntropyManager:
                 residue_id, residue.resname, level, "Conformational", S_conf_res
             )
 
-        self._data_logger.add_results_data(
-            group_id, level, "Transvibrational", S_trans
-        )
-        self._data_logger.add_results_data(
-            group_id, level, "Rovibrational", S_rot
-        )
-        self._data_logger.add_results_data(
-            group_id, level, "Conformational", S_conf
-        )
+        self._data_logger.add_results_data(group_id, level, "Transvibrational", S_trans)
+        self._data_logger.add_results_data(group_id, level, "Rovibrational", S_rot)
+        self._data_logger.add_results_data(group_id, level, "Conformational", S_conf)
 
     def _process_vibrational_entropy(
         self, group_id, number_frames, ve, level, force_matrix, torque_matrix, highest
@@ -418,12 +409,8 @@ class EntropyManager:
             torque_matrix, "torque", self._args.temperature, highest
         )
 
-        self._data_logger.add_results_data(
-            group_id, level, "Transvibrational", S_trans
-        )
-        self._data_logger.add_results_data(
-            group_id, level, "Rovibrational", S_rot
-        )
+        self._data_logger.add_results_data(group_id, level, "Transvibrational", S_trans)
+        self._data_logger.add_results_data(group_id, level, "Rovibrational", S_rot)
 
     def _process_conformational_entropy(
         self, group_id, ce, level, states, number_frames
@@ -442,9 +429,7 @@ class EntropyManager:
         """
         S_conf = ce.conformational_entropy_calculation(states[group_id], number_frames)
 
-        self._data_logger.add_results_data(
-            group_id, level, "Conformational", S_conf
-        )
+        self._data_logger.add_results_data(group_id, level, "Conformational", S_conf)
 
     def _finalize_molecule_results(self):
         """
@@ -594,12 +579,16 @@ class VibrationalEntropy(EntropyManager):
     vibrational modes and thermodynamic properties.
     """
 
-    def __init__(self, run_manager, args, universe, data_logger, level_manager, group_molecules):
+    def __init__(
+        self, run_manager, args, universe, data_logger, level_manager, group_molecules
+    ):
         """
         Initializes the VibrationalEntropy manager with all required components and
         defines physical constants used in vibrational entropy calculations.
         """
-        super().__init__(run_manager, args, universe, data_logger, level_manager, group_molecules)
+        super().__init__(
+            run_manager, args, universe, data_logger, level_manager, group_molecules
+        )
         self._PLANCK_CONST = 6.62607004081818e-34
 
     def frequency_calculation(self, lambdas, temp):
@@ -718,12 +707,16 @@ class ConformationalEntropy(EntropyManager):
     analysis using statistical mechanics principles.
     """
 
-    def __init__(self, run_manager, args, universe, data_logger, level_manager, group_molecules):
+    def __init__(
+        self, run_manager, args, universe, data_logger, level_manager, group_molecules
+    ):
         """
         Initializes the ConformationalEntropy manager with all required components and
         sets the gas constant used in conformational entropy calculations.
         """
-        super().__init__(run_manager, args, universe, data_logger, level_manager, group_molecules)
+        super().__init__(
+            run_manager, args, universe, data_logger, level_manager, group_molecules
+        )
 
     def assign_conformation(
         self, data_container, dihedral, number_frames, bin_width, start, end, step
@@ -755,7 +748,7 @@ class ConformationalEntropy(EntropyManager):
 
         # get the values of the angle for the dihedral
         # dihedral angle values have a range from -180 to 180
-        for timestep in data_container.trajectory[start:end+1:step]:
+        for timestep in data_container.trajectory[start : end + 1 : step]:
             timestep_index = timestep.frame - start
             value = dihedral.value()
             # we want postive values in range 0 to 360 to make the peak assignment

--- a/CodeEntropy/entropy.py
+++ b/CodeEntropy/entropy.py
@@ -69,7 +69,6 @@ class EntropyManager:
 
         self._handle_water_entropy(start, end, step)
         reduced_atom, number_molecules, levels, groups = self._initialize_molecules()
-        number_frames = len(reduced_atom.trajectory)
 
         force_matrices, torque_matrices = self._level_manager.build_covariance_matrices(
             self,
@@ -85,7 +84,6 @@ class EntropyManager:
         states_ua, states_res = self._level_manager.build_conformational_states(
             self,
             reduced_atom,
-            number_molecules,
             levels,
             groups,
             start,
@@ -847,12 +845,16 @@ class OrientationalEntropy(EntropyManager):
     and orientational degrees of freedom.
     """
 
-    def __init__(self, run_manager, args, universe, data_logger, level_manager):
+    def __init__(
+        self, run_manager, args, universe, data_logger, level_manager, group_molecules
+    ):
         """
         Initializes the OrientationalEntropy manager with all required components and
         sets the gas constant used in orientational entropy calculations.
         """
-        super().__init__(run_manager, args, universe, data_logger, level_manager)
+        super().__init__(
+            run_manager, args, universe, data_logger, level_manager, group_molecules
+        )
 
     def orientational_entropy_calculation(self, neighbours_dict):
         """

--- a/CodeEntropy/entropy.py
+++ b/CodeEntropy/entropy.py
@@ -52,8 +52,15 @@ class EntropyManager:
         reduced_atom, number_molecules, levels = self._initialize_molecules()
 
         force_matrices, torque_matrices, states_ua, states_res = (
-            self._build_covariance_matrices(
-                reduced_atom, number_molecules, levels, start, end, step, number_frames
+            self._level_manager.build_covariance_matrices(
+                self,
+                reduced_atom,
+                number_molecules,
+                levels,
+                start,
+                end,
+                step,
+                number_frames,
             )
         )
 
@@ -115,164 +122,6 @@ class EntropyManager:
         reduced_atom = self._get_reduced_universe()
         number_molecules, levels = self._level_manager.select_levels(reduced_atom)
         return reduced_atom, number_molecules, levels
-
-    def _build_covariance_matrices(
-        self, reduced_atom, number_molecules, levels, start, end, step, number_frames
-    ):
-        """
-        Construct force and torque covariance matrices for all molecules and levels.
-
-        Parameters:
-            reduced_atom (Universe): The reduced atom selection.
-            number_molecules (int): Number of molecules in the system.
-            levels (list): List of entropy levels per molecule.
-            start (int): Start frame index.
-            end (int): End frame index.
-            step (int): Step size for frame iteration.
-            number_frames (int): Total number of frames to process.
-
-        Returns:
-            tuple: A tuple containing:
-                - force_matrices (dict): Force covariance matrices by level.
-                - torque_matrices (dict): Torque covariance matrices by level.
-                - states_ua (dict): Conformational states at the united-atom level.
-                - states_res (list): Conformational states at the residue level.
-        """
-        force_matrices = {
-            "ua": {},
-            "res": [None] * number_molecules,
-            "poly": [None] * number_molecules,
-        }
-        torque_matrices = {
-            "ua": {},
-            "res": [None] * number_molecules,
-            "poly": [None] * number_molecules,
-        }
-        states_ua = {}
-        states_res = [None] * number_molecules
-
-        for timestep in reduced_atom.trajectory[start:end:step]:
-            time_index = timestep.frame - start
-
-            for mol_id in range(number_molecules):
-                mol = self._get_molecule_container(reduced_atom, mol_id)
-                for level in levels[mol_id]:
-                    self._update_force_torque_matrices(
-                        mol,
-                        mol_id,
-                        level,
-                        levels[mol_id],
-                        time_index,
-                        number_frames,
-                        force_matrices,
-                        torque_matrices,
-                    )
-
-        return force_matrices, torque_matrices, states_ua, states_res
-
-    def _update_force_torque_matrices(
-        self,
-        mol,
-        mol_id,
-        level,
-        level_list,
-        time_index,
-        num_frames,
-        force_matrices,
-        torque_matrices,
-    ):
-        """
-        Update force and torque matrices for a given molecule and entropy level.
-
-        Parameters:
-            mol (AtomGroup): The molecule to process.
-            mol_id (int): Index of the molecule.
-            level (str): Current entropy level ("united_atom", "residue", or "polymer").
-            level_list (list): List of levels for the molecule.
-            time_index (int): Index of the current frame.
-            num_frames (int): Total number of frames.
-            force_matrices (dict): Dictionary of force matrices to update.
-            torque_matrices (dict): Dictionary of torque matrices to update.
-        """
-        highest = level == level_list[-1]
-
-        if level == "united_atom":
-            for res_id, residue in enumerate(mol.residues):
-                key = (mol_id, res_id)
-                res = self._run_manager.new_U_select_atom(
-                    mol, f"index {residue.atoms.indices[0]}:{residue.atoms.indices[-1]}"
-                )
-                res.trajectory[time_index]
-
-                f_mat, t_mat = self._level_manager.get_matrices(
-                    res,
-                    level,
-                    num_frames,
-                    highest,
-                    force_matrices["ua"].get(key),
-                    torque_matrices["ua"].get(key),
-                )
-                force_matrices["ua"][key] = f_mat
-                torque_matrices["ua"][key] = t_mat
-
-        elif level in ["residue", "polymer"]:
-            mol.trajectory[time_index]
-            key = "res" if level == "residue" else "poly"
-            f_mat, t_mat = self._level_manager.get_matrices(
-                mol,
-                level,
-                num_frames,
-                highest,
-                force_matrices[key][mol_id],
-                torque_matrices[key][mol_id],
-            )
-            force_matrices[key][mol_id] = f_mat
-            torque_matrices[key][mol_id] = t_mat
-
-    def _compute_dihedral_conformations(
-        self,
-        selector,
-        level,
-        ce,
-        number_frames,
-        bin_width,
-        start,
-        end,
-        step,
-    ):
-        """
-        Compute dihedral conformations for a given selector and entropy level.
-
-        Parameters:
-            selector (AtomGroup): Atom selection to compute dihedrals for.
-            level (str): Entropy level ("united_atom" or "residue").
-            ce (ConformationalEntropy): Conformational entropy calculator.
-            number_frames (int): Number of frames to process.
-            bin_width (float): Bin width for dihedral angle discretization.
-            start (int): Start frame index.
-            end (int): End frame index.
-            step (int): Step size for frame iteration.
-
-        Returns:
-            tuple: A tuple containing:
-                - states (list): List of conformation strings per frame.
-                - dihedrals (list): List of dihedral angle definitions.
-        """
-        dihedrals = self._level_manager.get_dihedrals(selector, level)
-        num_dihedrals = len(dihedrals)
-
-        conformation = np.zeros((num_dihedrals, number_frames))
-        for i, dihedral in enumerate(dihedrals):
-            conformation[i] = ce.assign_conformation(
-                selector, dihedral, number_frames, bin_width, start, end, step
-            )
-
-        states = [
-            "".join(str(int(conformation[d][f])) for d in range(num_dihedrals))
-            for f in range(number_frames)
-        ]
-
-        return states, dihedrals
 
     def _compute_entropies(
         self,
@@ -346,15 +195,17 @@ class EntropyManager:
                             res_container, "not name H*"
                         )
 
-                        states_ua[key], _ = self._compute_dihedral_conformations(
-                            heavy_res,
-                            level,
-                            ce,
-                            number_frames,
-                            bin_width,
-                            start,
-                            end,
-                            step,
+                        states_ua[key] = (
+                            self._level_manager.compute_dihedral_conformations(
+                                heavy_res,
+                                level,
+                                ce,
+                                number_frames,
+                                bin_width,
+                                start,
+                                end,
+                                step,
+                            )
                         )
 
                     self._process_united_atom_entropy(
@@ -372,7 +223,7 @@ class EntropyManager:
                     )
 
                 elif level == "residue":
-                    states_res, _ = self._compute_dihedral_conformations(
+                    states_res = self._level_manager.compute_dihedral_conformations(
                         mol, level, ce, number_frames, bin_width, start, end, step
                     )
 

--- a/CodeEntropy/entropy.py
+++ b/CodeEntropy/entropy.py
@@ -81,15 +81,15 @@ class EntropyManager:
         )
 
         # Initialise force and torque matrices
-        force_matrix_ua = [[] for _ in range(number_residues)]
-        force_matrix_res = [[] for _ in range(number_molecules)]
-        force_matrix_poly = [[] for _ in range(number_molecules)]
-        torque_matrix_ua = [[] for _ in range(number_residues)]
-        torque_matrix_res = [[] for _ in range(number_molecules)]
-        torque_matrix_poly = [[] for _ in range(number_molecules)]
+        force_matrix_ua = [None for _ in range(number_residues)]
+        force_matrix_res = [None for _ in range(number_molecules)]
+        force_matrix_poly = [None for _ in range(number_molecules)]
+        torque_matrix_ua = [None for _ in range(number_residues)]
+        torque_matrix_res = [None for _ in range(number_molecules)]
+        torque_matrix_poly = [None for _ in range(number_molecules)]
 
-        states_ua = []
-        states_res = []
+        states_ua = [None for _ in range(number_residues)]
+        states_res = [None for _ in range(number_molecules)]
 
         for timestep in reduced_atom.trajectory[start:end:step]:
             # time_index = timestep.frame - start
@@ -172,27 +172,29 @@ class EntropyManager:
                         )
 
                         dihedrals = self._level_manager.get_dihedrals(heavy_res, level)
-                        states_ua[res_id] = ce.assign_conformations(
-                            heavy_res,
-                            dihedrals,
+                        for dihedral in dihedrals:
+                            states_ua[res_id] = ce.assign_conformation(
+                                heavy_res,
+                                dihedral,
+                                number_frames,
+                                bin_width,
+                                start,
+                                end,
+                                step,
+                            )
+
+                if level == "residue":
+                    dihedrals = self._level_manager.get_dihedrals(mol_container, level)
+                    for dihedral in dihedrals:
+                        states_res[molecule_id] = ce.assign_conformation(
+                            mol_container,
+                            dihedral,
                             number_frames,
                             bin_width,
                             start,
                             end,
                             step,
                         )
-
-                if level == "residue":
-                    dihedrals = self._level_manager.get_dihedrals(mol_container, level)
-                    states_res[molecule_id] = ce.assign_conformations(
-                        mol_container,
-                        dihedrals,
-                        number_frames,
-                        bin_width,
-                        start,
-                        end,
-                        step,
-                    )
 
         # Do the entropy calculations
         for molecule_id in range(number_molecules):

--- a/CodeEntropy/entropy.py
+++ b/CodeEntropy/entropy.py
@@ -63,6 +63,7 @@ class EntropyManager:
 
         reduced_atom = self._get_reduced_universe()
         number_molecules, levels = self._level_manager.select_levels(reduced_atom)
+        number_residues = len(reduced_atom.residues)
 
         ve = VibrationalEntropy(
             self._run_manager,
@@ -79,86 +80,102 @@ class EntropyManager:
             self._level_manager,
         )
 
-        for molecule_id in range(number_molecules):
-            mol_container = self._get_molecule_container(reduced_atom, molecule_id)
+        # Initialise force and torque matrices
+        force_matrix_ua = [[] for _ in range(number_residues)]
+        force_matrix_res = [[] for _ in range(number_molecules)]
+        force_matrix_poly = [[] for _ in range(number_molecules)]
+        torque_matrix_ua = [[] for _ in range(number_residues)]
+        torque_matrix_res = [[] for _ in range(number_molecules)]
+        torque_matrix_poly = [[] for _ in range(number_molecules)]
 
-            for level in levels[molecule_id]:
+        for timestep in reduced_atom.trajectory[start:end:step]:
+            time_index = timestep.frame - start
+
+            for molecule_id in range(number_molecules):
+                mol_container = self._get_molecule_container(reduced_atom, molecule_id)
+
+                for level in levels[molecule_id]:
+                    # Identify if level is the highest (molecule) level
+                    highest_level = level == levels[molecule_id][-1]
+
+                    # Get matrices for vibrational entropy calculations
+                    if level == "united_atom":
+                       for res_id, residue in enumerate(mol_container.residues):
+                           res_container = self._run_manager.new_U_select_atom(
+                               mol_container,
+                               f"index {residue.atoms.indices[0]}:{residue.atoms.indices[-1]}",
+                               )
+
+                           force_matrix, torque_matrix = self._level_manager.get_matrices(
+                               res_container,level, number_frames, 
+                               highest_level, force_matrix_ua[res_id],
+                               torque_matrix_ua[res_id]
+                           )
+                           force_matrix_ua[res_id] = force_matrix
+                           torque_matrix_ua[res_id] = torque_matrix
+
+                    elif level == "residue":
+                        force_matrix, torque_matrix = self._level_manager.get_matrices(mol_container,level,number_frames,highest_level, force_matrix_res[molecule_id],torque_matrix_res[molecule_id])
+                        force_matrix_res[molecule_id] = force_matrix
+                        torque_matrix_res[molecule_id] = torque_matrix
+                        
+                    elif level =="polymer":
+                        force_matrix, torque_matrix = self._level_manager.get_matrices(mol_container,level,number_frames,highest_level, force_matrix_poly[molecule_id],torque_matrix_poly[molecule_id])
+                        force_matrix_poly[molecule_id] = force_matrix
+                        torque_matrix_poly[molecule_id] = torque_matrix
+
+                    #TODO When function is ready
+                    # Get environment information for orientational entropy
+                ##    if highest_level:
+                ##        number_neighbours = get_neighbours()
+    
+       # Get states for conformational entropy calculation
+       bin_width = self._args.bin_width
+       for molecule_id in range(number_molecule):
+           mol_container = self._get_molecule_container(reduced_atom, molecule_id)
+           for level in levels[molecule_id]:
+               if level == "united_atom":
+                   for res_id, residue in enumerate(mol_container.residues):
+                       res_container = self._run_manager.new_U_select_atom(
+                           mol_container,
+                           f"index {residue.atoms.indices[0]}:{residue.atoms.indices[-1]}",
+                           )
+                       heavy_res = self._run_manager.new_U_select_atom(
+                           res_container, "not name H*"
+                           )
+
+                       dihedrals = self._level_manager.get_dihedrals(heavy_res, level)
+                       states_ua[res_id] = ce.assign_conformations(heavy_res, dihedrals, number_frames, bin_width, start, end, step)
+
+               if level == "residue":
+                   dihedrals = self._level_manager.get_dihedrals(mol_container, level)
+                   states_res[molecule_id] = ce.assign_conformations(mol_container, dihedrals, number_frames, bin_width, start, end, step)
+
+       # Do the entropy calculations
+       for molecule_id in range(number_molecules):
+           mol_container = self._get_molecule_container(reduced_atom, molecule_id)
+           for level in levels[molecule_id]:
+                # Identify if level is the highest (molecule) level
                 highest_level = level == levels[molecule_id][-1]
-                if level == "united_atom":
-                    self._process_united_atom_level(
-                        molecule_id,
-                        mol_container,
-                        ve,
-                        ce,
-                        level,
-                        start,
-                        end,
-                        step,
-                        number_frames,
-                        highest_level,
-                    )
 
-                    logger.debug(
-                        "%s level: molecule_data: %s",
-                        level,
-                        self._data_logger.molecule_data,
-                    )
-                    logger.debug(
-                        "%s level: residue_data: %s",
-                        level,
-                        self._data_logger.residue_data,
-                    )
+               if level == "united_atom":
+                   for res_id, residue in enumerate(mol_container.residues):
+                       self._process_united_atom_level(molecule_id, res_id, ve, ce, force_matrix_ua[res_id], torque_matrix_ua[res_id], states_ua[res_id], highest)
 
-                elif level in ("polymer", "residue"):
-                    self._process_vibrational_only_levels(
-                        molecule_id,
-                        mol_container,
-                        ve,
-                        level,
-                        start,
-                        end,
-                        step,
-                        number_frames,
-                        highest_level,
-                    )
+               elif level == "residue":
+                   self._process_vibrational_entropy(molecule_id, mol_container, ve, level, force_matrix_res[molecule_id], torque_matrix_res[molecule_id], highest)
+                   self._process_conformational_entropy(molecule_id, mol_container, ce, states_res[molecule_id])
 
-                    logger.debug(
-                        "%s level: molecule_data: %s",
-                        level,
-                        self._data_logger.molecule_data,
-                    )
-                    logger.debug(
-                        "%s level: residue_data: %s",
-                        level,
-                        self._data_logger.residue_data,
-                    )
+               elif level == "polymer":
+                   self._process_vibrational_entropy(molecule_id, mol_container, ve, level, force_matrix_poly[molecule_id], torque_matrix_poly[molecule_id], highest)
+              
+               #TODO when orientational entropy function is ready
+           ##    if highest:
+             ##      self._process_orientational_entropy()
 
-                if level == "residue":
-                    self._process_conformational_residue_level(
-                        molecule_id,
-                        mol_container,
-                        ce,
-                        level,
-                        start,
-                        end,
-                        step,
-                        number_frames,
-                    )
+           self._finalize_molecule_results()
 
-                    logger.debug(
-                        "%s level: molecule_data: %s",
-                        level,
-                        self._data_logger.molecule_data,
-                    )
-                    logger.debug(
-                        "%s level: residue_data: %s",
-                        level,
-                        self._data_logger.residue_data,
-                    )
-
-        self._finalize_molecule_results()
-
-        self._data_logger.log_tables()
+           self._data_logger.log_tables()
 
     def _get_trajectory_bounds(self):
         """
@@ -228,8 +245,8 @@ class EntropyManager:
         selection_string = f"index {frag.indices[0]}:{frag.indices[-1]}"
         return self._run_manager.new_U_select_atom(universe, selection_string)
 
-    def _process_united_atom_level(
-        self, mol_id, mol_container, ve, ce, level, start, end, step, n_frames, highest
+    def _process_united_atom_entropy(
+        self, mol_id, res_id, ve, ce, force_matrix, torque_matrix, states, highest
     ):
         """
         Calculates translational, rotational, and conformational entropy at the
@@ -246,21 +263,9 @@ class EntropyManager:
             highest (bool): Whether this is the highest level of resolution for
             the molecule.
         """
-        bin_width = self._args.bin_width
         S_trans, S_rot, S_conf = 0, 0, 0
+
         for residue_id, residue in enumerate(mol_container.residues):
-            res_container = self._run_manager.new_U_select_atom(
-                mol_container,
-                f"index {residue.atoms.indices[0]}:{residue.atoms.indices[-1]}",
-            )
-            heavy_res = self._run_manager.new_U_select_atom(
-                res_container, "not name H*"
-            )
-
-            force_matrix, torque_matrix = self._level_manager.get_matrices(
-                res_container, level, start, end, step, n_frames, highest
-            )
-
             S_trans_res = ve.vibrational_entropy_calculation(
                 force_matrix, "force", self._args.temperature, highest
             )
@@ -268,9 +273,8 @@ class EntropyManager:
                 torque_matrix, "torque", self._args.temperature, highest
             )
 
-            dihedrals = self._level_manager.get_dihedrals(heavy_res, level)
             S_conf_res = ce.conformational_entropy_calculation(
-                heavy_res, dihedrals, bin_width, start, end, step, n_frames
+                mol_id, states
             )
 
             S_trans += S_trans_res
@@ -297,26 +301,24 @@ class EntropyManager:
             residue.resname, level, "Conformational", S_conf
         )
 
-    def _process_vibrational_only_levels(
-        self, mol_id, mol_container, ve, level, start, end, step, n_frames, highest
+    def _process_vibrational_entropy(
+        self, mol_id, mol_container, ve, level, force_matrix, torque_matrix, highest
     ):
         """
-        Calculates vibrational entropy at levels where conformational entropy is
-        not considered.
+        Calculates vibrational entropy.
 
         Args:
             mol_id (int): Molecule ID.
             mol_container (Universe): Selected molecule's universe.
             ve: VibrationalEntropy object.
-            level (str): Current granularity level ('polymer' or 'residue').
-            start, end, step (int): Trajectory frame parameters.
-            n_frames (int): Number of trajectory frames.
+            level (str): Current granularity level.
+            force_matrix : Force covariance matrix
+            torque_matrix : Torque covariance matrix
             highest (bool): Flag indicating if this is the highest granularity
             level.
         """
-        force_matrix, torque_matrix = self._level_manager.get_matrices(
-            mol_container, level, start, end, step, n_frames, highest
-        )
+        force_matrix, torque_matrix = self.force_matrix, self.torque_matrix
+
         S_trans = ve.vibrational_entropy_calculation(
             force_matrix, "force", self._args.temperature, highest
         )
@@ -331,9 +333,7 @@ class EntropyManager:
             residue.resname, level, "Rovibrational", S_rot
         )
 
-    def _process_conformational_residue_level(
-        self, mol_id, mol_container, ce, level, start, end, step, n_frames
-    ):
+    def _process_conformational_entropy(self, mol_id, mol_container, ce, states):
         """
         Computes conformational entropy at the residue level (whole-molecule dihedral
         analysis).
@@ -346,11 +346,7 @@ class EntropyManager:
             start, end, step (int): Frame bounds.
             n_frames (int): Number of frames used.
         """
-        bin_width = self._args.bin_width
-        dihedrals = self._level_manager.get_dihedrals(mol_container, level)
-        S_conf = ce.conformational_entropy_calculation(
-            mol_container, dihedrals, bin_width, start, end, step, n_frames
-        )
+        S_conf = ce.conformational_entropy_calculation(states)
         residue = mol_container.residues[mol_id]
         self._data_logger.add_results_data(
             residue.resname, level, "Conformational", S_conf

--- a/CodeEntropy/entropy.py
+++ b/CodeEntropy/entropy.py
@@ -197,6 +197,22 @@ class EntropyManager:
                             step,
                         )
 
+        force_matrix_ua = {k: v / number_frames for k, v in force_matrix_ua.items()}
+        torque_matrix_ua = {k: v / number_frames for k, v in torque_matrix_ua.items()}
+
+        force_matrix_res = [
+            f / number_frames if f is not None else None for f in force_matrix_res
+        ]
+        torque_matrix_res = [
+            t / number_frames if t is not None else None for t in torque_matrix_res
+        ]
+        force_matrix_poly = [
+            f / number_frames if f is not None else None for f in force_matrix_poly
+        ]
+        torque_matrix_poly = [
+            t / number_frames if t is not None else None for t in torque_matrix_poly
+        ]
+
         # Do the entropy calculations
         for molecule_id in range(number_molecules):
             mol_container = self._get_molecule_container(reduced_atom, molecule_id)

--- a/CodeEntropy/entropy.py
+++ b/CodeEntropy/entropy.py
@@ -211,21 +211,19 @@ class EntropyManager:
                                 step,
                             )
 
-                    for res_id, residue in enumerate(mol_container.residues):
-                        key = (molecule_id, res_id)
-                        self._process_united_atom_entropy(
-                            molecule_id,
-                            mol_container,
-                            res_id,
-                            ve,
-                            ce,
-                            level,
-                            force_matrix_ua[key],
-                            torque_matrix_ua[key],
-                            states_ua[key],
-                            highest_level,
-                            number_frames,
-                        )
+                    self._process_united_atom_entropy(
+                        molecule_id,
+                        mol_container,
+                        res_id,
+                        ve,
+                        ce,
+                        level,
+                        force_matrix_ua,
+                        torque_matrix_ua,
+                        states_ua,
+                        highest_level,
+                        number_frames,
+                    )
 
                 elif level == "residue":
 
@@ -378,14 +376,19 @@ class EntropyManager:
         S_trans, S_rot, S_conf = 0, 0, 0
 
         for residue_id, residue in enumerate(mol_container.residues):
+
+            key = (mol_id, residue_id)
+
             S_trans_res = ve.vibrational_entropy_calculation(
-                force_matrix, "force", self._args.temperature, highest
+                force_matrix[key], "force", self._args.temperature, highest
             )
             S_rot_res = ve.vibrational_entropy_calculation(
-                torque_matrix, "torque", self._args.temperature, highest
+                torque_matrix[key], "torque", self._args.temperature, highest
             )
 
-            S_conf_res = ce.conformational_entropy_calculation(states, number_frames)
+            S_conf_res = ce.conformational_entropy_calculation(
+                states[key], number_frames
+            )
 
             S_trans += S_trans_res
             S_rot += S_rot_res
@@ -457,7 +460,7 @@ class EntropyManager:
             start, end, step (int): Frame bounds.
             n_frames (int): Number of frames used.
         """
-        S_conf = ce.conformational_entropy_calculation(states, number_frames)
+        S_conf = ce.conformational_entropy_calculation(states[mol_id], number_frames)
         residue = mol_container.residues[mol_id]
         self._data_logger.add_results_data(
             residue.resname, level, "Conformational", S_conf

--- a/CodeEntropy/entropy.py
+++ b/CodeEntropy/entropy.py
@@ -104,7 +104,6 @@ class EntropyManager:
 
                     # Get matrices for vibrational entropy calculations
                     if level == "united_atom":
-                        mol_container.trajectory[time_index]
                         for res_id, residue in enumerate(mol_container.residues):
                             key = (molecule_id, res_id)
 

--- a/CodeEntropy/group_molecules.py
+++ b/CodeEntropy/group_molecules.py
@@ -1,7 +1,7 @@
 import logging
-import MDAnalysis as mda
 
 logger = logging.getLogger(__name__)
+
 
 class GroupMolecules:
     """
@@ -57,7 +57,7 @@ class GroupMolecules:
 
     def _by_molecules(self, universe):
         """
-        Group molecules by chemical type. 
+        Group molecules by chemical type.
         Based on number of atoms and atom names.
         """
 

--- a/CodeEntropy/group_molecules.py
+++ b/CodeEntropy/group_molecules.py
@@ -1,0 +1,91 @@
+import logging
+import MDAnalysis as mda
+
+logger = logging.getLogger(__name__)
+
+class GroupMolecules:
+    """
+    Groups molecules for averaging.
+    """
+
+    def __init__(self):
+        """
+        Initializes the class with relevant information.
+
+        Args:
+            run_manager: Manager for universe and selection operations.
+            args: Argument namespace containing user parameters.
+            universe: MDAnalysis universe representing the simulation system.
+            data_logger: Logger for storing and exporting entropy data.
+        """
+        self._molecule_groups = None
+
+    def grouping_molecules(self, universe, grouping):
+        """
+        Grouping molecules by desired level of detail.
+        """
+
+        molecule_groups = {}
+
+        if grouping == "each":
+            molecule_groups = self._by_none(universe)
+
+        if grouping == "molecules":
+            molecule_groups = self._by_molecules(universe)
+
+        return molecule_groups
+
+    def _by_none(self, universe):
+        """
+        Don't group molecules. Every molecule is in its own group.
+        """
+
+        # fragments is MDAnalysis terminology for molecules
+        number_molecules = len(universe.atoms.fragments)
+
+        molecule_groups = {}
+
+        for molecule_i in range(number_molecules):
+            molecule_groups[molecule_i] = [molecule_i]
+
+        number_groups = len(molecule_groups)
+
+        logger.info(f"Number of molecule groups: {number_groups}")
+        logger.debug(f"Molecule groups are: {molecule_groups}")
+
+        return molecule_groups
+
+    def _by_molecules(self, universe):
+        """
+        Group molecules by chemical type. 
+        Based on number of atoms and atom names.
+        """
+
+        # fragments is MDAnalysis terminology for molecules
+        number_molecules = len(universe.atoms.fragments)
+        fragments = universe.atoms.fragments
+
+        molecule_groups = {}
+
+        for molecule_i in range(number_molecules):
+            names_i = fragments[molecule_i].names
+            number_atoms_i = len(names_i)
+
+            for molecule_j in range(number_molecules):
+                names_j = fragments[molecule_j].names
+                number_atoms_j = len(names_j)
+
+                if number_atoms_i == number_atoms_j and (names_i == names_j).all:
+                    if molecule_j in molecule_groups.keys():
+                        molecule_groups[molecule_j].append(molecule_i)
+                    else:
+                        molecule_groups[molecule_j] = []
+                        molecule_groups[molecule_j].append(molecule_i)
+                    break
+
+        number_groups = len(molecule_groups)
+
+        logger.info(f"Number of molecule groups: {number_groups}")
+        logger.debug(f"Molecule groups are: {molecule_groups}")
+
+        return molecule_groups

--- a/CodeEntropy/levels.py
+++ b/CodeEntropy/levels.py
@@ -978,7 +978,10 @@ class LevelManager:
                             ce,
                         )
 
-                        states_res[group_id] += states
+                        if states_res[group_id] is None:
+                            states_res[group_id] = states
+                        else:
+                            states_res[group_id] += states
 
         logger.debug(f"states_ua {states_ua}")
         logger.debug(f"states_res {states_res}")

--- a/CodeEntropy/levels.py
+++ b/CodeEntropy/levels.py
@@ -899,7 +899,6 @@ class LevelManager:
         self,
         entropy_manager,
         reduced_atom,
-        number_molecules,
         levels,
         groups,
         start,
@@ -916,7 +915,6 @@ class LevelManager:
         Parameters:
             entropy_manager (EntropyManager): Instance of the EntropyManager
             reduced_atom (Universe): The reduced atom selection.
-            number_molecules (int): Number of molecules in the system.
             levels (list): List of entropy levels per molecule.
             start (int): Start frame index.
             end (int): End frame index.

--- a/CodeEntropy/levels.py
+++ b/CodeEntropy/levels.py
@@ -70,8 +70,13 @@ class LevelManager:
         return number_molecules, levels
 
     def get_matrices(
-        self, data_container, level, number_frames, highest_level, 
-        force_matrix, torque_matrix
+        self,
+        data_container,
+        level,
+        number_frames,
+        highest_level,
+        force_matrix,
+        torque_matrix,
     ):
         """
         Function to create the force matrix needed for the transvibrational entropy
@@ -97,10 +102,8 @@ class LevelManager:
         number_beads = len(list_of_beads)
 
         # initialize force and torque arrays
-        weighted_forces = [
-            [0 for x in range(number_beads) ]
-        weighted_torques = [
-            [0 for x in range(number_beads) ]
+        weighted_forces = [[0 for x in range(number_beads)]]
+        weighted_torques = [[0 for x in range(number_beads)]]
 
         # Calculate forces/torques for each bead
         for bead_index in range(number_beads):
@@ -113,10 +116,8 @@ class LevelManager:
             weighted_forces[bead_index] = self.get_weighted_forces(
                 data_container, list_of_beads[bead_index], trans_axes, highest_level
             )
-            weighted_torques[bead_index] = (
-                self.get_weighted_torques(
-                    data_container, list_of_beads[bead_index], rot_axes
-                )
+            weighted_torques[bead_index] = self.get_weighted_torques(
+                data_container, list_of_beads[bead_index], rot_axes
             )
 
         # Make covariance matrices - looping over pairs of beads
@@ -162,10 +163,10 @@ class LevelManager:
             ]
         )
 
-    #    # fliter zeros to remove any rows/columns that are all zero
-     #   force_matrix = self.filter_zero_rows_columns(force_matrix)
-     #   torque_matrix = self.filter_zero_rows_columns(torque_matrix)
-        
+        #    # fliter zeros to remove any rows/columns that are all zero
+        #   force_matrix = self.filter_zero_rows_columns(force_matrix)
+        #   torque_matrix = self.filter_zero_rows_columns(torque_matrix)
+
         # Add forces/torques from this time frame into the matrices
         force_matrix = np.add(force_matrix, force_block)
         torque_matrix = np.add(torque_matrix, torque_block)

--- a/CodeEntropy/levels.py
+++ b/CodeEntropy/levels.py
@@ -941,10 +941,12 @@ class LevelManager:
                         for res_id, residue in enumerate(mol.residues):
                             key = (group_id, res_id)
 
-                            res_container = entropy_manager._run_manager.new_U_select_atom(
-                                mol,
-                                f"index {residue.atoms.indices[0]}:"
-                                f"{residue.atoms.indices[-1]}",
+                            res_container = (
+                                entropy_manager._run_manager.new_U_select_atom(
+                                    mol,
+                                    f"index {residue.atoms.indices[0]}:"
+                                    f"{residue.atoms.indices[-1]}",
+                                )
                             )
                             heavy_res = entropy_manager._run_manager.new_U_select_atom(
                                 res_container, "not name H*"
@@ -979,7 +981,6 @@ class LevelManager:
                         )
 
                         states_res[group_id] += states
-                            
 
         logger.debug(f"states_ua {states_ua}")
         logger.debug(f"states_res {states_res}")

--- a/CodeEntropy/levels.py
+++ b/CodeEntropy/levels.py
@@ -377,7 +377,7 @@ class LevelManager:
             trans_axes = data_container.atoms.principal_axes()
             rot_axes = data_container.atoms.principal_axes()
 
-        if level == "residue":
+        elif level == "residue":
             # Translation
             # for residues use principal axes of whole molecule for translation
             trans_axes = data_container.atoms.principal_axes()
@@ -409,7 +409,7 @@ class LevelManager:
                 # use spherical coordinates function to get rotational axes
                 rot_axes = self.get_sphCoord_axes(vector)
 
-        if level == "united_atom":
+        elif level == "united_atom":
             # Translation
             # for united atoms use principal axes of residue for translation
             trans_axes = data_container.residues.principal_axes()

--- a/CodeEntropy/levels.py
+++ b/CodeEntropy/levels.py
@@ -375,15 +375,19 @@ class LevelManager:
                 f"not name H* and bonded index {index}"
             )
 
-            # center at position of heavy atom
-            atom_group = data_container.select_atoms(f"index {index}")
-            center = atom_group.positions[0]
+            if len(atom_set) == 0:
+                # if no bonds to other residues use pricipal axes of residue
+                rot_axes = data_container.residues.principal_axes()
+            else:
+                # center at position of heavy atom
+                atom_group = data_container.select_atoms(f"index {index}")
+                center = atom_group.positions[0]
 
-            # get vector for average position of hydrogens
-            vector = self.get_avg_pos(atom_set, center)
+                # get vector for average position of hydrogens
+                vector = self.get_avg_pos(atom_set, center)
 
-            # use spherical coordinates function to get rotational axes
-            rot_axes = self.get_sphCoord_axes(vector)
+                # use spherical coordinates function to get rotational axes
+                rot_axes = self.get_sphCoord_axes(vector)
 
         logger.debug(f"Translational Axes: {trans_axes}")
         logger.debug(f"Rotational Axes: {rot_axes}")

--- a/CodeEntropy/run.py
+++ b/CodeEntropy/run.py
@@ -10,8 +10,8 @@ from CodeEntropy.config.arg_config_manager import ConfigManager
 from CodeEntropy.config.data_logger import DataLogger
 from CodeEntropy.config.logging_config import LoggingConfig
 from CodeEntropy.entropy import EntropyManager
-from CodeEntropy.levels import LevelManager
 from CodeEntropy.group_molecules import GroupMolecules
+from CodeEntropy.levels import LevelManager
 
 logger = logging.getLogger(__name__)
 
@@ -152,7 +152,6 @@ class RunManager:
                     data_logger=self._data_logger,
                     level_manager=level_manager,
                     group_molecules=group_molecules,
-                    
                 )
 
                 entropy_manager.execute()

--- a/CodeEntropy/run.py
+++ b/CodeEntropy/run.py
@@ -11,6 +11,7 @@ from CodeEntropy.config.data_logger import DataLogger
 from CodeEntropy.config.logging_config import LoggingConfig
 from CodeEntropy.entropy import EntropyManager
 from CodeEntropy.levels import LevelManager
+from CodeEntropy.group_molecules import GroupMolecules
 
 logger = logging.getLogger(__name__)
 
@@ -140,6 +141,9 @@ class RunManager:
                 # Create LevelManager instance
                 level_manager = LevelManager()
 
+                # Create GroupMolecules instance
+                group_molecules = GroupMolecules()
+
                 # Inject all dependencies into EntropyManager
                 entropy_manager = EntropyManager(
                     run_manager=self,
@@ -147,6 +151,8 @@ class RunManager:
                     universe=u,
                     data_logger=self._data_logger,
                     level_manager=level_manager,
+                    group_molecules=group_molecules,
+                    
                 )
 
                 entropy_manager.execute()

--- a/tests/test_CodeEntropy/test_group_molecules.py
+++ b/tests/test_CodeEntropy/test_group_molecules.py
@@ -1,0 +1,95 @@
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from CodeEntropy.group_molecules import GroupMolecules
+
+
+class TestMain(unittest.TestCase):
+    """
+    Unit tests for the functionality of GroupMolecules class.
+    """
+
+    def setUp(self):
+        """
+        Set up a temporary directory as the working directory before each test.
+        Initialize GroupMolecules instance.
+        """
+        self.test_dir = tempfile.mkdtemp(prefix="CodeEntropy_")
+        self._orig_dir = os.getcwd()
+        os.chdir(self.test_dir)
+        self.group_molecules = GroupMolecules()
+
+    def tearDown(self):
+        """
+        Clean up by removing the temporary directory and restoring the original working
+        directory.
+        """
+        os.chdir(self._orig_dir)
+        shutil.rmtree(self.test_dir)
+
+    def test_by_none_returns_individual_groups(self):
+        """
+        Test _by_none returns each molecule in its own group when grouping is 'each'.
+        """
+        mock_universe = MagicMock()
+        # Simulate universe.atoms.fragments has 3 molecules
+        mock_universe.atoms.fragments = [MagicMock(), MagicMock(), MagicMock()]
+
+        groups = self.group_molecules._by_none(mock_universe)
+        expected = {0: [0], 1: [1], 2: [2]}
+        self.assertEqual(groups, expected)
+
+    def test_by_molecules_groups_by_chemical_type(self):
+        """
+        Test _by_molecules groups molecules with identical atom counts and names
+        together.
+        """
+        mock_universe = MagicMock()
+
+        # Use numpy arrays for .names to allow numpy-like comparison
+        fragment0 = MagicMock()
+        fragment0.names = np.array(["H", "O", "H"])
+        fragment1 = MagicMock()
+        fragment1.names = np.array(["H", "O", "H"])
+        fragment2 = MagicMock()
+        fragment2.names = np.array(["C", "C", "H", "H"])
+
+        mock_universe.atoms.fragments = [fragment0, fragment1, fragment2]
+
+        groups = self.group_molecules._by_molecules(mock_universe)
+
+        # Expect first two grouped, third separate
+        self.assertIn(0, groups)
+        self.assertIn(2, groups)
+        self.assertCountEqual(groups[0], [0, 1])
+        self.assertEqual(groups[2], [2])
+
+    def test_grouping_molecules_dispatches_correctly(self):
+        """
+        Test grouping_molecules method dispatches to correct grouping strategy.
+        """
+        mock_universe = MagicMock()
+        mock_universe.atoms.fragments = [MagicMock()]  # Just 1 molecule to keep simple
+
+        # When grouping='each', calls _by_none
+        groups = self.group_molecules.grouping_molecules(mock_universe, "each")
+        self.assertEqual(groups, {0: [0]})
+
+        # When grouping='molecules', calls _by_molecules (mock to test call)
+        self.group_molecules._by_molecules = MagicMock(return_value={"mocked": [42]})
+        groups = self.group_molecules.grouping_molecules(mock_universe, "molecules")
+        self.group_molecules._by_molecules.assert_called_once_with(mock_universe)
+        self.assertEqual(groups, {"mocked": [42]})
+
+        # If grouping unknown, should return empty dict
+        groups = self.group_molecules.grouping_molecules(mock_universe, "unknown")
+        self.assertEqual(groups, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_CodeEntropy/test_group_molecules.py
+++ b/tests/test_CodeEntropy/test_group_molecules.py
@@ -51,7 +51,6 @@ class TestMain(unittest.TestCase):
         """
         mock_universe = MagicMock()
 
-        # Use numpy arrays for .names to allow numpy-like comparison
         fragment0 = MagicMock()
         fragment0.names = np.array(["H", "O", "H"])
         fragment1 = MagicMock()


### PR DESCRIPTION
### Summary
<!-- Provide a brief description of the PR's purpose here. -->
This PR signifies a large and significant restructure in how `CodeEntropy` performs entropy calculations. The core change involves transitioning from a per-molecule computation model to a per-timestep approach. Additionally, entropy values are now grouped across molecule types, improving the interpretability and consistency of the results. These changes lay the groundwork for more scalable and scientifically robust analyses.

### Changes:
<!-- List all the changes introduced in this PR. -->
Refactor entropy computation granularity:
- Replaced the per-molecule entropy calculation with a per-timestep approach to improve temporal resolution and consistency.
- Refactored the entropy computation workflow into modular functions for better maintainability and readability.
- Ensured correct slicing of timesteps during entropy accumulation to avoid misalignment across frames.

Introduce molecule-type Grouping:
- Implemented grouping of molecules by type.
- Updated `build_conformational_states` and related functions to support type-based aggregation.

Testing and validation:
- Added new test cases to validate per-timestep entropy computation and molecule-type.
- Refined existing tests to reflect the updated methodology.

### Impact
- Enhances scientific accuracy and resolution of entropy calculations.
- Improves code modularity and maintainability for future extensions.
- Enables more meaningful comparisons across molecule types in complex systems.
- Reduces computational redundancy and improves performance in matrix operations.