### PR TITLE
Add parallelism and temperature to water entropy method call. 

### DIFF
--- a/CodeEntropy/entropy.py
+++ b/CodeEntropy/entropy.py
@@ -405,7 +405,7 @@ class EntropyManager:
             step (int): Step size.
         """
         Sorient_dict, _, vibrations, _ = (
-            GetSolvent.get_interfacial_water_orient_entropy(universe, start, end, step)
+            GetSolvent.get_interfacial_water_orient_entropy(universe, start, end, step, parallel=True)
         )
 
         # Log per-residue entropy using helper functions

--- a/CodeEntropy/entropy.py
+++ b/CodeEntropy/entropy.py
@@ -405,7 +405,13 @@ class EntropyManager:
             step (int): Step size.
         """
         Sorient_dict, _, vibrations, _ = (
-            GetSolvent.get_interfacial_water_orient_entropy(universe, start, end, step, parallel=True)
+            GetSolvent.get_interfacial_water_orient_entropy(
+                universe, 
+                start, 
+                end, 
+                step, 
+                self._args.temperature, 
+                parallel=True)
         )
 
         # Log per-residue entropy using helper functions


### PR DESCRIPTION
### Summary
This PR is to include the parallel and temperature parameters to the waterentropy function call such that the default temperature set in waterentropy is overridden by that set in CE config file and also to cause water entropy to run in parallel.

### Changes
<!-- List all the changes introduced in this PR. -->
Update function call to waterentropy with temperature and parallel params:
- add in self.args.temperature as the temperature parameter
-  add in parallel=True to trigger parallel execution



### Impact
This will make sure that temperature in waterentropy is set to the CE value and will trigger water entropy to run in parallel. We still need to parallelise CE but when we do the context should be passed also into WE so that we avoid the overhead of dual dask setups.

closes #125 