### PR TITLE
Remove conditional MDAnalysis install logic

### DIFF
--- a/.github/workflows/mdanalysis-compatibility.yaml
+++ b/.github/workflows/mdanalysis-compatibility.yaml
@@ -29,12 +29,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -e .[testing]
-
-          if [ "${{ matrix.mdanalysis-version }}" = "latest" ]; then
-            pip install MDAnalysis
-          else
-            pip install "MDAnalysis==${{ matrix.mdanalysis-version }}"
-          fi
+          pip install "MDAnalysis==${{ matrix.mdanalysis-version }}"
 
       - name: Run compatibility tests
         run: pytest --cov CodeEntropy --cov-report=term-missing --cov-append


### PR DESCRIPTION
## Summary
Removes unused MDAnalysis version check from the compatibility workflow now that the version is pinned.

## Changes

### Simplify MDAnalysis installation
- Removed conditional logic for handling the `latest` version.
- MDAnalysis is now always installed using the pinned version.

## Impact
- Reduces workflow complexity.
- Prevents unnecessary branching and potential cross-platform issues.
