### PR TITLE
Fix Renovate workflow to correctly detect repository

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -26,3 +26,4 @@ jobs:
         env:
           RENOVATE_CONFIG_FILE: ".github/renovate.json"
           LOG_LEVEL: debug
+          RENOVATE_REPOSITORIES: "CCPBioSim/CodeEntropy"


### PR DESCRIPTION
## Summary

This PR fixes an issue in the Renovate CI workflow where Renovate was unable to detect the `CCPBioSim/CodeEntropy` repository. As a result, scheduled Renovate runs were exiting without processing any dependencies.

## Changes

### Added explicit repository configuration
- Added `RENOVATE_REPOSITORIES=CCPBioSim/CodeEntropy` to the workflow to ensure Renovate correctly identifies the target repository.

## Impact
- Renovate will now run successfully on this repository.
- Scheduled updates and dependency PRs will resume functioning as expected.
