### PR TITLE
Switch GitHub Workflows to Standard Cron Schedule 

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
     "group:recommended"
   ],
   "rangeStrategy": "pin",
-  "schedule": ["before 8am on weekdays"],
+  "schedule": ["0 8 * * 1-5"],
   "labels": ["dependencies"],
   "lockFileMaintenance": {
     "enabled": true

--- a/.github/workflows/project-ci.yaml
+++ b/.github/workflows/project-ci.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   pull_request:
   schedule:
-    - cron: '0 8 * * 1'
+    - cron: '0 8 * * 1-5'
   workflow_dispatch:  
   
 jobs:


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the PR's purpose here. -->
This PR addresses a fix that is needed to ensure that Renovate is able to run successfully and make PRs, currently the schedule is not set up correctly, so a switch to using the cron scheduling system is needed.

## Changes
<!-- List all the changes introduced in this PR. -->
### Update workflows within `.github/`:
- Update `.github/renovate.json` to use the cron schedule of `0 8 * * 1-5`
- Update `.github/workflows/project-ci.yaml` to run only on weekdays using the cron schedule of `0 8 * * 1-5`

## Impact
- This will ensure that Renovate is able to successfully run on the `CodeEntropy` repository.
- The project CI will only run when needed during the working week and reduce the wasted GitHub actions minutes during the weekend.