### PR TITLE
Ensure Workflow uses Renovate Approved Cron Schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
     "group:recommended"
   ],
   "rangeStrategy": "pin",
-  "schedule": ["0 8 * * 1-5"],
+  "schedule": ["* 8 * * 1-5"],
   "labels": ["dependencies"],
   "lockFileMaintenance": {
     "enabled": true


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the PR's purpose here. -->
This PR addresses a fix that is needed to ensure that Renovate is able to run successfully and make PRs, currently the schedule is not set up correctly, Renovate requires a `*` on the minute to run successfully.

## Changes
<!-- List all the changes introduced in this PR. -->
### Update workflows within `.github/`:
- Update `.github/renovate.json` to use the cron schedule of `* 8 * * 1-5`

## Impact
- This will ensure that Renovate is able to successfully run on the `CodeEntropy` repository, using the Renovate approved cron structure.