### PR TITLE
Remove `lockFileMaintenance` configuration from `renovate.json`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,9 +12,6 @@
   "rangeStrategy": "replace",
   "schedule": ["* 8 * * 1-5"],
   "labels": ["dependencies"],
-  "lockFileMaintenance": {
-    "enabled": true
-  },
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
## Summary
This PR removes `lockFileMaintenance` from the `renovate.json` configuration. Since `CodeEntropy` does not currently use lock files and Renovate does not yet support Python's upcoming `pylock.toml` **[PEP 751](https://peps.python.org/pep-0751/)**,  format, lockfile maintenance is not currently functional. By removing it now, we simplify configuration and prepare to introduce a lock file once Renovate adds support.

## Changes

### Remove lockfile maintenance from Renovate config
- Removed the `lockFileMaintenance` section from `renovate.json`.

## Impact
- Reduces configuration noise by removing unused lockfile settings.
- No behavioral change to dependency updates.
- Positions the project to adopt `pylock.toml` once supported, improving reproducibility in future.
- Avoids confusion or non-functional Renovate config entries.
- Closes issue #236