### PR TITLE
Introduce Table for GitHub Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+CodeEntropy
+==============================
+
 | Category       | Badges |
 |----------------|--------|
 | **Build**      | [![CodeEntropy CI](https://github.com/CCPBioSim/CodeEntropy/actions/workflows/project-ci.yaml/badge.svg)](https://github.com/CCPBioSim/CodeEntropy/actions/workflows/project-ci.yaml) |
@@ -5,9 +8,6 @@
 | **PyPI**       | ![PyPI - Status](https://img.shields.io/pypi/status/codeentropy?logo=pypi&logoColor=white) ![PyPI - Version](https://img.shields.io/pypi/v/codeentropy?logo=pypi&logoColor=white)  ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/CodeEntropy) ![PyPI - Total Downloads](https://img.shields.io/pepy/dt/codeentropy?logo=pypi&logoColor=white&color=blue) ![PyPI - Monthly Downloads](https://img.shields.io/pypi/dm/CodeEntropy?logo=pypi&logoColor=white&color=blue)|
 | **Quality**    | [![Coverage Status](https://coveralls.io/repos/github/CCPBioSim/CodeEntropy/badge.svg?branch=main)](https://coveralls.io/github/CCPBioSim/CodeEntropy?branch=main) |
 
-
-CodeEntropy
-==============================
 CodeEntropy is a Python package for computing the configurational entropy of macromolecular systems using forces sampled from molecular dynamics (MD) simulations. It implements the multiscale cell correlation method to provide accurate and efficient entropy estimates, supporting a wide range of applications in molecular simulation and statistical mechanics.
 
 <p align="center">


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the PR's purpose here. -->
This PR updates the `README.md` to introduce a table for GitHub badges. The aim is to standardise badge presentation and improve readability so users can quickly assess the current status of the codebase at a glance.

## Changes
<!-- List all the changes introduced in this PR. -->
### Introduce badge table
- Moved all existing GitHub badges into a single table layout.
### Remove redundant copyright notice
- Removed the copyright year from the `README.md`, as this information is already maintained in the `LICENSE` document.

## Impact

<!-- Bullet-point the expected impact this PR will have on the codebase. -->
- Improved readability and visual consistency of the `README.md`.