### PR TITLE
Add Parallel Build for Coveralls in CI

### DIFF
--- a/.github/workflows/project-ci.yaml
+++ b/.github/workflows/project-ci.yaml
@@ -35,16 +35,7 @@ jobs:
         uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-  finish:
-    needs: tests
-    if: ${{ always() }}
-    runs-on: ubuntu-24.04
-    steps:
-    - name: Coveralls Finished
-      uses: coverallsapp/github-action@v2.3.7
-      with:
-        parallel-finished: true
+          parallel: true       
 
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the PR's purpose here. -->
This PR will introduce a parallel build option for coveralls to avoid the failing PRs which come in with quick succession to each other.

## Changes
<!-- List all the changes introduced in this PR. -->
### Add Parallel Build Option in `project-ci.yaml`
- Add an extra step with `parallel-finished: true`

## Impact
- This will ensure that any future CI runs involving coveralls uses the parallel version and avoid the crash of jobs