### PR TITLE
Include Zenodo DOI within `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ CodeEntropy
 |----------------|--------|
 | **Build**      | [![CodeEntropy CI](https://github.com/CCPBioSim/CodeEntropy/actions/workflows/project-ci.yaml/badge.svg)](https://github.com/CCPBioSim/CodeEntropy/actions/workflows/project-ci.yaml) |
 | **Documentation** | [![Docs - Status](https://app.readthedocs.org/projects/codeentropy/badge/?version=latest)](https://codeentropy.readthedocs.io/en/latest/?badge=latest) |
+| **Citation**      | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17570722.svg)](https://doi.org/10.5281/zenodo.17570722) |
 | **PyPI**       | ![PyPI - Status](https://img.shields.io/pypi/status/codeentropy?logo=pypi&logoColor=white) ![PyPI - Version](https://img.shields.io/pypi/v/codeentropy?logo=pypi&logoColor=white)  ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/CodeEntropy) ![PyPI - Total Downloads](https://img.shields.io/pepy/dt/codeentropy?logo=pypi&logoColor=white&color=blue) ![PyPI - Monthly Downloads](https://img.shields.io/pypi/dm/CodeEntropy?logo=pypi&logoColor=white&color=blue)|
 | **Quality**    | [![Coverage Status](https://coveralls.io/repos/github/CCPBioSim/CodeEntropy/badge.svg?branch=main)](https://coveralls.io/github/CCPBioSim/CodeEntropy?branch=main) |
 


### PR DESCRIPTION
## Summary
This PR introduces the addition of the Zenodo DOI to the `README.md` to improve citation, attribution, and discoverability of the deposited release.

## Changes
### Added DOI to `README.md`
- Added a new column to the `README.md` table to display the Zenodo DOI
- Included the Zenodo GitHub badge for the project DOI

## Impact
- Improves the citability of the project by clearly exposing the Zenodo DOI
- Enhances visibility and reuse by making the archival record explicit