### PR TITLE
Update DOI badge link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ CodeEntropy
 |----------------|--------|
 | **Build**      | [![CodeEntropy CI](https://github.com/CCPBioSim/CodeEntropy/actions/workflows/project-ci.yaml/badge.svg)](https://github.com/CCPBioSim/CodeEntropy/actions/workflows/project-ci.yaml) |
 | **Documentation** | [![Docs - Status](https://app.readthedocs.org/projects/codeentropy/badge/?version=latest)](https://codeentropy.readthedocs.io/en/latest/?badge=latest) |
-| **Citation**      | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17570722.svg)](https://doi.org/10.5281/zenodo.17570722) |
+| **Citation**      | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17570721.svg)](https://doi.org/10.5281/zenodo.17570721) |
 | **PyPI**       | ![PyPI - Status](https://img.shields.io/pypi/status/codeentropy?logo=pypi&logoColor=white) ![PyPI - Version](https://img.shields.io/pypi/v/codeentropy?logo=pypi&logoColor=white)  ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/CodeEntropy) ![PyPI - Total Downloads](https://img.shields.io/pepy/dt/codeentropy?logo=pypi&logoColor=white&color=blue) ![PyPI - Monthly Downloads](https://img.shields.io/pypi/dm/CodeEntropy?logo=pypi&logoColor=white&color=blue)|
 | **Quality**    | [![Coverage Status](https://coveralls.io/repos/github/CCPBioSim/CodeEntropy/badge.svg?branch=main)](https://coveralls.io/github/CCPBioSim/CodeEntropy?branch=main) |
 


### PR DESCRIPTION
## Summary
This PR updates the DOI link in `README.md` to use Zenodo’s **concept DOI** for `CodeEntropy`, ensuring it always resolves to the latest release rather than a specific archived version.

## Changes
### `README.md`
- Updated the Zenodo DOI from `17570722` (version-specific DOI) to `17570721` (concept DOI / persistent identifier).

## Impact
- Ensures that each new `CodeEntropy` release is automatically referenced correctly from the `README.md`.
- Prevents the documentation from becoming outdated by always linking to the current published version on Zenodo.