### PR TITLE
Fix Conda recipe version update in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -160,7 +160,8 @@ jobs:
 
       - name: Set version in conda recipe
         run: |
-          sed -i -E "s/^{% set version = \".*\" %}$/{% set version = \"${{ github.event.inputs.version }}\" %}/" conda-recipe/meta.yaml
+          sed -i "s/^{% set version = \".*\" %}$/{% set version = \"${{ github.event.inputs.version }}\" %}/" conda-recipe/meta.yaml
+          grep '{% set version' conda-recipe/meta.yaml
 
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@v3


### PR DESCRIPTION
## Summary
Fix the release workflow to correctly update the Conda recipe version before building and publishing to Anaconda.org.

## Changes
### Fix conda recipe version replacement
- Updated the `sed` command in the release workflow to correctly match and replace the Jinja version line in `conda-recipe/meta.yaml`.
- Removed use of extended regex (`-E`) which caused failures when processing `{% ... %}` syntax.
- Added a `grep` check to confirm the version is updated in CI logs.

## Impact
- Restores the ability to publish CodeEntropy to the CCPBioSim Anaconda.org channel.
- Prevents release workflow failures caused by invalid regex handling in the Conda recipe.