### PR TITLE
Fixing #317 Invalid Eigenvalues

### DIFF
--- a/CodeEntropy/levels/level_dag.py
+++ b/CodeEntropy/levels/level_dag.py
@@ -179,6 +179,7 @@ class LevelDAG:
         Notes:
             The task title shows the current frame index being processed.
         """
+        u = shared_data["reduced_universe"]
         n_frames = shared_data["n_frames"]
 
         task: TaskID | None = None
@@ -196,11 +197,11 @@ class LevelDAG:
                 title="Initializing",
             )
 
-        for frame_index in range(n_frames):
+        for ts in u.trajectory:
             if progress is not None and task is not None:
-                progress.update(task, title=f"Frame {frame_index}")
+                progress.update(task, title=f"Frame {ts.frame}")
 
-            frame_out = self._frame_dag.execute_frame(shared_data, frame_index)
+            frame_out = self._frame_dag.execute_frame(shared_data, ts.frame)
             self._reduce_one_frame(shared_data, frame_out)
 
             if progress is not None and task is not None:

--- a/tests/regression/baselines/benzaldehyde/axes_off.json
+++ b/tests/regression/baselines/benzaldehyde/axes_off.json
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/benzaldehyde/combined_forcetorque_false.json
+++ b/tests/regression/baselines/benzaldehyde/combined_forcetorque_false.json
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/benzaldehyde/default.json
+++ b/tests/regression/baselines/benzaldehyde/default.json
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/benzaldehyde/frame_window.json
+++ b/tests/regression/baselines/benzaldehyde/frame_window.json
@@ -26,20 +26,20 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {
       "components": {
-        "united_atom:Transvibrational": 0.06976323861519099,
-        "united_atom:Rovibrational": 43.1148685234083,
-        "residue:FTmat-Transvibrational": 81.88770108142911,
-        "residue:FTmat-Rovibrational": 54.95209390854072,
+        "united_atom:Transvibrational": 40.30267601961045,
+        "united_atom:Rovibrational": 38.21906858443615,
+        "residue:FTmat-Transvibrational": 73.41098578352612,
+        "residue:FTmat-Rovibrational": 57.881504393660364,
         "united_atom:Conformational": 0.0,
         "residue:Conformational": 0.0,
         "residue:Orientational": 20.481571492615355
       },
-      "total": 200.50599824460866
+      "total": 230.29580627384846
     }
   }
 }

--- a/tests/regression/baselines/benzaldehyde/grouping_each.json
+++ b/tests/regression/baselines/benzaldehyde/grouping_each.json
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/benzaldehyde/rad.json
+++ b/tests/regression/baselines/benzaldehyde/rad.json
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/benzaldehyde/selection_subset.json
+++ b/tests/regression/baselines/benzaldehyde/selection_subset.json
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/benzene/axes_off.json
+++ b/tests/regression/baselines/benzene/axes_off.json
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/benzene/combined_forcetorque_off.json
+++ b/tests/regression/baselines/benzene/combined_forcetorque_off.json
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/benzene/default.json
+++ b/tests/regression/baselines/benzene/default.json
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/benzene/frame_window.json
+++ b/tests/regression/baselines/benzene/frame_window.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw6/test_regression_matches_baseli0/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw5/test_regression_matches_baseli0/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,20 +26,20 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {
       "components": {
-        "united_atom:Transvibrational": 0.19795850062580336,
-        "united_atom:Rovibrational": 37.022046871408385,
-        "residue:FTmat-Transvibrational": 89.61712603903918,
-        "residue:FTmat-Rovibrational": 59.882255851985164,
+        "united_atom:Transvibrational": 11.46552036084548,
+        "united_atom:Rovibrational": 34.98492056748493,
+        "residue:FTmat-Transvibrational": 71.83491878606151,
+        "residue:FTmat-Rovibrational": 55.6098400281744,
         "united_atom:Conformational": 0.0,
         "residue:Conformational": 0.0,
         "residue:Orientational": 0.0
       },
-      "total": 186.71938726305854
+      "total": 173.89519974256632
     }
   }
 }

--- a/tests/regression/baselines/benzene/grouping_each.json
+++ b/tests/regression/baselines/benzene/grouping_each.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw6/test_regression_matches_baseli1/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw5/test_regression_matches_baseli1/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "each",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/benzene/rad.json
+++ b/tests/regression/baselines/benzene/rad.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw5/test_regression_matches_baseli0/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw6/test_regression_matches_baseli0/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/benzene/selection_subset.json
+++ b/tests/regression/baselines/benzene/selection_subset.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw5/test_regression_matches_baseli1/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw6/test_regression_matches_baseli1/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/cyclohexane/axes_off.json
+++ b/tests/regression/baselines/cyclohexane/axes_off.json
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/cyclohexane/combined_forcetorque_off.json
+++ b/tests/regression/baselines/cyclohexane/combined_forcetorque_off.json
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/cyclohexane/default.json
+++ b/tests/regression/baselines/cyclohexane/default.json
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/cyclohexane/frame_window.json
+++ b/tests/regression/baselines/cyclohexane/frame_window.json
@@ -26,20 +26,20 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {
       "components": {
-        "united_atom:Transvibrational": 0.9922566704968832,
-        "united_atom:Rovibrational": 25.157330630108138,
-        "residue:FTmat-Transvibrational": 88.28792477558463,
-        "residue:FTmat-Rovibrational": 65.39813357771244,
+        "united_atom:Transvibrational": 17.398382397359153,
+        "united_atom:Rovibrational": 73.96792995794405,
+        "residue:FTmat-Transvibrational": 76.4267996157354,
+        "residue:FTmat-Rovibrational": 63.30469126284744,
         "united_atom:Conformational": 0.0,
         "residue:Conformational": 0.0,
         "residue:Orientational": 0.0
       },
-      "total": 179.83564565390208
+      "total": 231.09780323388605
     }
   }
 }

--- a/tests/regression/baselines/cyclohexane/grouping_each.json
+++ b/tests/regression/baselines/cyclohexane/grouping_each.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw10/test_regression_matches_baseli0/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw9/test_regression_matches_baseli0/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "each",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/cyclohexane/rad.json
+++ b/tests/regression/baselines/cyclohexane/rad.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw10/test_regression_matches_baseli1/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw9/test_regression_matches_baseli1/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/cyclohexane/selection_subset.json
+++ b/tests/regression/baselines/cyclohexane/selection_subset.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw9/test_regression_matches_baseli0/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw10/test_regression_matches_baseli0/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/dna/axes_off.json
+++ b/tests/regression/baselines/dna/axes_off.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw9/test_regression_matches_baseli1/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw10/test_regression_matches_baseli1/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,36 +26,36 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {
       "components": {
         "united_atom:Transvibrational": 0.0,
-        "united_atom:Rovibrational": 138.6554635683915,
+        "united_atom:Rovibrational": 1.2269044878385265,
         "residue:Transvibrational": 0.0,
-        "residue:Rovibrational": 3.7744745512812843,
-        "polymer:FTmat-Transvibrational": 13.548865634429543,
+        "residue:Rovibrational": 27.45710747332319,
+        "polymer:FTmat-Transvibrational": 48.62026970762269,
         "polymer:FTmat-Rovibrational": 0.0,
         "united_atom:Conformational": 10.584542990557836,
         "residue:Conformational": 0.0,
         "polymer:Orientational": 4.758905336627712
       },
-      "total": 171.3222520812879
+      "total": 92.64772999596995
     },
     "1": {
       "components": {
         "united_atom:Transvibrational": 0.0,
-        "united_atom:Rovibrational": 0.018570889591209457,
+        "united_atom:Rovibrational": 1.7972774672527945,
         "residue:Transvibrational": 0.0,
-        "residue:Rovibrational": 6.178603242071742,
-        "polymer:FTmat-Transvibrational": 14.075720078226187,
+        "residue:Rovibrational": 25.287669468441067,
+        "polymer:FTmat-Transvibrational": 60.47397935339153,
         "polymer:FTmat-Rovibrational": 0.0,
         "united_atom:Conformational": 5.292271495278918,
         "residue:Conformational": 0.0,
         "polymer:Orientational": 4.758905336627712
       },
-      "total": 30.32407104179577
+      "total": 97.61010312099201
     }
   }
 }

--- a/tests/regression/baselines/dna/combined_forcetorque_off.json
+++ b/tests/regression/baselines/dna/combined_forcetorque_off.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw11/test_regression_matches_baseli0/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw12/test_regression_matches_baseli0/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/dna/default.json
+++ b/tests/regression/baselines/dna/default.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw11/test_regression_matches_baseli1/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw12/test_regression_matches_baseli1/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/dna/frame_window.json
+++ b/tests/regression/baselines/dna/frame_window.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw12/test_regression_matches_baseli0/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw11/test_regression_matches_baseli0/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,36 +26,36 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {
       "components": {
         "united_atom:Transvibrational": 0.0,
-        "united_atom:Rovibrational": 138.656450674966,
+        "united_atom:Rovibrational": 1.5821720528374943,
         "residue:Transvibrational": 0.0,
-        "residue:Rovibrational": 3.7688488322030405,
-        "polymer:FTmat-Transvibrational": 13.548865634429543,
+        "residue:Rovibrational": 27.397449238560412,
+        "polymer:FTmat-Transvibrational": 48.62026970762269,
         "polymer:FTmat-Rovibrational": 0.0,
         "united_atom:Conformational": 10.584542990557836,
         "residue:Conformational": 0.0,
         "polymer:Orientational": 4.758905336627712
       },
-      "total": 171.31761346878415
+      "total": 92.94333932620614
     },
     "1": {
       "components": {
         "united_atom:Transvibrational": 0.0,
-        "united_atom:Rovibrational": 0.03040252662727023,
+        "united_atom:Rovibrational": 2.5277936366208014,
         "residue:Transvibrational": 0.0,
-        "residue:Rovibrational": 6.102344853380676,
-        "polymer:FTmat-Transvibrational": 14.075720078226187,
+        "residue:Rovibrational": 24.80670067454149,
+        "polymer:FTmat-Transvibrational": 60.47397935339153,
         "polymer:FTmat-Rovibrational": 0.0,
         "united_atom:Conformational": 5.292271495278918,
         "residue:Conformational": 0.0,
         "polymer:Orientational": 4.758905336627712
       },
-      "total": 30.259644290140763
+      "total": 97.85965049646045
     }
   }
 }

--- a/tests/regression/baselines/dna/grouping_each.json
+++ b/tests/regression/baselines/dna/grouping_each.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw12/test_regression_matches_baseli1/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw11/test_regression_matches_baseli1/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "each",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/dna/selection_subset.json
+++ b/tests/regression/baselines/dna/selection_subset.json
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/ethyl-acetate/axes_off.json
+++ b/tests/regression/baselines/ethyl-acetate/axes_off.json
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/ethyl-acetate/combined_forcetorque_off.json
+++ b/tests/regression/baselines/ethyl-acetate/combined_forcetorque_off.json
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/ethyl-acetate/default.json
+++ b/tests/regression/baselines/ethyl-acetate/default.json
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/ethyl-acetate/frame_window.json
+++ b/tests/regression/baselines/ethyl-acetate/frame_window.json
@@ -26,20 +26,20 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {
       "components": {
-        "united_atom:Transvibrational": 0.7923511180672675,
-        "united_atom:Rovibrational": 71.06179603616442,
-        "residue:FTmat-Transvibrational": 83.06772281534602,
-        "residue:FTmat-Rovibrational": 48.869571179742096,
+        "united_atom:Transvibrational": 28.312711247966337,
+        "united_atom:Rovibrational": 51.99036142818903,
+        "residue:FTmat-Transvibrational": 67.80560626717748,
+        "residue:FTmat-Rovibrational": 55.1631201009248,
         "united_atom:Conformational": 8.635471458692102,
         "residue:Conformational": 0.0,
         "residue:Orientational": 0.0
       },
-      "total": 212.4269126080119
+      "total": 211.90727050294976
     }
   }
 }

--- a/tests/regression/baselines/ethyl-acetate/grouping_each.json
+++ b/tests/regression/baselines/ethyl-acetate/grouping_each.json
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/ethyl-acetate/rad.json
+++ b/tests/regression/baselines/ethyl-acetate/rad.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw11/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw12/test_regression_matches_baseli2/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/ethyl-acetate/selection_subset.json
+++ b/tests/regression/baselines/ethyl-acetate/selection_subset.json
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/methane/axes_off.json
+++ b/tests/regression/baselines/methane/axes_off.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 112.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw12/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw11/test_regression_matches_baseli2/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/methane/combined_forcetorque_off.json
+++ b/tests/regression/baselines/methane/combined_forcetorque_off.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 112.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw11/test_regression_matches_baseli3/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw12/test_regression_matches_baseli3/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/methane/default.json
+++ b/tests/regression/baselines/methane/default.json
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/methane/frame_window.json
+++ b/tests/regression/baselines/methane/frame_window.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 112.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw12/test_regression_matches_baseli3/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw4/test_regression_matches_baseli2/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,17 +26,17 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {
       "components": {
-        "united_atom:Transvibrational": 42.1495717236188,
-        "united_atom:Rovibrational": 39.226038972684975,
+        "united_atom:Transvibrational": 40.70376001258969,
+        "united_atom:Rovibrational": 33.778792396823484,
         "united_atom:Conformational": 0.0,
         "united_atom:Orientational": 0.0
       },
-      "total": 81.37561069630377
+      "total": 74.48255240941317
     }
   }
 }

--- a/tests/regression/baselines/methane/grouping_each.json
+++ b/tests/regression/baselines/methane/grouping_each.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 112.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw10/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw15/test_regression_matches_baseli2/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "each",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/methane/rad.json
+++ b/tests/regression/baselines/methane/rad.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 112.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw6/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw11/test_regression_matches_baseli3/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/methane/selection_subset.json
+++ b/tests/regression/baselines/methane/selection_subset.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 112.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw4/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw3/test_regression_matches_baseli2/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/methanol/axes_off.json
+++ b/tests/regression/baselines/methanol/axes_off.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw0/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw5/test_regression_matches_baseli2/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/methanol/combined_forcetorque_off.json
+++ b/tests/regression/baselines/methanol/combined_forcetorque_off.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw15/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw14/test_regression_matches_baseli2/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/methanol/default.json
+++ b/tests/regression/baselines/methanol/default.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw3/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw0/test_regression_matches_baseli2/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/methanol/frame_window.json
+++ b/tests/regression/baselines/methanol/frame_window.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw14/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw7/test_regression_matches_baseli2/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,20 +26,20 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {
       "components": {
         "united_atom:Transvibrational": 0.0,
-        "united_atom:Rovibrational": 43.01626564417083,
-        "residue:FTmat-Transvibrational": 74.91032652381023,
-        "residue:FTmat-Rovibrational": 32.84395719280311,
+        "united_atom:Rovibrational": 34.6755419354061,
+        "residue:FTmat-Transvibrational": 61.225853411706915,
+        "residue:FTmat-Rovibrational": 29.74713345439499,
         "united_atom:Conformational": 0.0,
         "residue:Conformational": 0.0,
         "residue:Orientational": 0.0
       },
-      "total": 150.77054936078417
+      "total": 125.64852880150801
     }
   }
 }

--- a/tests/regression/baselines/methanol/grouping_each.json
+++ b/tests/regression/baselines/methanol/grouping_each.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw12/test_regression_matches_baseli4/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw9/test_regression_matches_baseli2/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "each",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/methanol/rad.json
+++ b/tests/regression/baselines/methanol/rad.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw9/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw13/test_regression_matches_baseli3/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/methanol/selection_subset.json
+++ b/tests/regression/baselines/methanol/selection_subset.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw7/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw10/test_regression_matches_baseli2/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/octonol/axes_off.json
+++ b/tests/regression/baselines/octonol/axes_off.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw13/test_regression_matches_baseli3/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw11/test_regression_matches_baseli4/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/octonol/combined_forcetorque_off.json
+++ b/tests/regression/baselines/octonol/combined_forcetorque_off.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw9/test_regression_matches_baseli3/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw10/test_regression_matches_baseli3/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/octonol/default.json
+++ b/tests/regression/baselines/octonol/default.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw12/test_regression_matches_baseli5/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw3/test_regression_matches_baseli3/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/octonol/frame_window.json
+++ b/tests/regression/baselines/octonol/frame_window.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw6/test_regression_matches_baseli3/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw0/test_regression_matches_baseli3/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,20 +26,20 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {
       "components": {
-        "united_atom:Transvibrational": 0.5593770868041172,
-        "united_atom:Rovibrational": 13.488941026792721,
-        "residue:FTmat-Transvibrational": 79.60741090497159,
-        "residue:FTmat-Rovibrational": 60.864478264811964,
+        "united_atom:Transvibrational": 65.86600728016141,
+        "united_atom:Rovibrational": 162.26463085986236,
+        "residue:FTmat-Transvibrational": 74.84326467422125,
+        "residue:FTmat-Rovibrational": 60.95710412746361,
         "united_atom:Conformational": 16.651144380045313,
         "residue:Conformational": 0.0,
         "residue:Orientational": 25.79114991860739
       },
-      "total": 196.9625015820331
+      "total": 406.37330124036134
     }
   }
 }

--- a/tests/regression/baselines/octonol/grouping_each.json
+++ b/tests/regression/baselines/octonol/grouping_each.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw15/test_regression_matches_baseli3/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw5/test_regression_matches_baseli3/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "each",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/octonol/rad.json
+++ b/tests/regression/baselines/octonol/rad.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw0/test_regression_matches_baseli3/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw15/test_regression_matches_baseli3/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/octonol/selection_subset.json
+++ b/tests/regression/baselines/octonol/selection_subset.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw3/test_regression_matches_baseli3/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw10/test_regression_matches_baseli4/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/water/axes_off.json
+++ b/tests/regression/baselines/water/axes_off.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw12/test_regression_matches_baseli6/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw3/test_regression_matches_baseli4/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/water/combined_forcetorque_off.json
+++ b/tests/regression/baselines/water/combined_forcetorque_off.json
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/water/default.json
+++ b/tests/regression/baselines/water/default.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw15/test_regression_matches_baseli4/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw5/test_regression_matches_baseli4/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/water/frame_window.json
+++ b/tests/regression/baselines/water/frame_window.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw0/test_regression_matches_baseli4/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw15/test_regression_matches_baseli4/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,17 +26,17 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {
       "components": {
-        "united_atom:Transvibrational": 48.25352455371683,
-        "united_atom:Rovibrational": 23.131550866115766,
+        "united_atom:Transvibrational": 46.684099714230925,
+        "united_atom:Rovibrational": 17.694014405444744,
         "united_atom:Conformational": 0.0,
         "united_atom:Orientational": 0.0
       },
-      "total": 71.38507541983259
+      "total": 64.37811411967567
     }
   }
 }

--- a/tests/regression/baselines/water/grouping_each.json
+++ b/tests/regression/baselines/water/grouping_each.json
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/water/rad.json
+++ b/tests/regression/baselines/water/rad.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw5/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw11/test_regression_matches_baseli5/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/water/selection_subset.json
+++ b/tests/regression/baselines/water/selection_subset.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw9/test_regression_matches_baseli4/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw6/test_regression_matches_baseli2/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/water/water_off.json
+++ b/tests/regression/baselines/water/water_off.json
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw6/test_regression_matches_baseli4/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw7/test_regression_matches_baseli4/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": false,
     "grouping": "molecules",
@@ -26,7 +26,7 @@
     "python": "3.13.5",
     "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
     "codeentropy_version": "2.1.1",
-    "git_sha": "ac1f2ac999409433f391e45cffd116cdecc46096"
+    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
   },
   "groups": {
     "0": {

--- a/tests/unit/CodeEntropy/levels/test_level_dag_reduction.py
+++ b/tests/unit/CodeEntropy/levels/test_level_dag_reduction.py
@@ -75,7 +75,7 @@ def test_run_frame_stage_calls_execute_frame_for_each_ts(simple_ts_list):
     u = MagicMock()
     u.trajectory = simple_ts_list
 
-    shared = {"reduced_universe": u, "start": 0, "end": 3, "step": 1, "n_frames": 3}
+    shared = {"reduced_universe": u, "start": 0, "end": 10, "step": 1, "n_frames": 10}
 
     dag._frame_dag = MagicMock()
     dag._frame_dag.execute_frame.side_effect = lambda shared_data, frame_index: {
@@ -87,5 +87,5 @@ def test_run_frame_stage_calls_execute_frame_for_each_ts(simple_ts_list):
 
     dag._run_frame_stage(shared)
 
-    assert dag._frame_dag.execute_frame.call_count == 3
-    assert dag._reduce_one_frame.call_count == 3
+    assert dag._frame_dag.execute_frame.call_count == 10
+    assert dag._reduce_one_frame.call_count == 10


### PR DESCRIPTION
## Summary
Resolving Issue #317 by correcting the looping over frames.

## Changes
### Fixing level_dag.py
- looping over trajectory frames in _run_frame_stage

### Tests
- update regression baselines

## Impact
- By looping over frames (not just frame index) in level_dag.py, the code is now collecting data from all the relevant frames not just the first one, so the sampling is correct.
- This will reduce the number of invalid (zero, negative, or imaginary) eigenvalues and improve the vibrational entropy results.
