### PR TITLE
Fixing skipped transvibrational entropy.

### DIFF
--- a/CodeEntropy/entropy/nodes/vibrational.py
+++ b/CodeEntropy/entropy/nodes/vibrational.py
@@ -323,7 +323,7 @@ class VibrationalEntropyNode:
             EntropyPair containing translational entropy (from force covariance) and
             rotational entropy (from torque covariance).
         """
-        if fmat is None or tmat is None:
+        if fmat is None and tmat is None:
             return EntropyPair(trans=0.0, rot=0.0)
 
         f = self._mat_ops.filter_zero_rows_columns(
@@ -333,7 +333,7 @@ class VibrationalEntropyNode:
             np.asarray(tmat), atol=self._zero_atol
         )
 
-        if f.size == 0 or t.size == 0:
+        if f.size == 0 and t.size == 0:
             return EntropyPair(trans=0.0, rot=0.0)
 
         s_trans = ve.vibrational_entropy_calculation(

--- a/tests/unit/CodeEntropy/entropy/nodes/test_vibrational_node.py
+++ b/tests/unit/CodeEntropy/entropy/nodes/test_vibrational_node.py
@@ -321,7 +321,7 @@ def test_compute_force_torque_entropy_returns_zero_when_missing_matrix(shared_gr
     node = VibrationalEntropyNode()
     ve = MagicMock()
     pair = node._compute_force_torque_entropy(
-        ve=ve, temp=298.0, fmat=None, tmat=np.eye(3), flexible=0, highest=True
+        ve=ve, temp=298.0, fmat=None, tmat=None, flexible=0, highest=True
     )
     assert pair == EntropyPair(trans=0.0, rot=0.0)
 


### PR DESCRIPTION
## Summary
This pull requests fixes a small error in calculating vibrational entropy. It was giving 0 for both translational and rotational vibrational entropy if either force or torque matrices were 0 so in a few cases was missing translational entropy when the torques were zero and the forces were not zero.

## Changes
### Fix missing entropy
- Changed 2 instances of "or" to "and" in entropy/nodes/vibrational.py : _compute_force_torqe_entropy()

### Tests
- Corrected one test

## Impact
- Molecules with beads that do not have torques will now have the transvibrational entropy calculated and not missed.
