### PR TITLE
Investigate intermittent regression test failures in GitHub Actions CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,6 +7,13 @@ concurrency:
   group: pr-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  OMP_NUM_THREADS: 1
+  MKL_NUM_THREADS: 1
+  OPENBLAS_NUM_THREADS: 1
+  NUMEXPR_NUM_THREADS: 1
+  PYTHONHASHSEED: 0
+
 jobs:
   unit:
     name: Unit
@@ -34,7 +41,7 @@ jobs:
           python -m pip install -e .[testing]
 
       - name: Pytest (unit) • ${{ matrix.os }}, ${{ matrix.python-version }}
-        run: python -m pytest tests/unit
+        run: python -m pytest tests/unit --cache-clear
 
   discover-systems:
     name: Discover regression systems
@@ -84,23 +91,34 @@ jobs:
           python-version: "3.14"
           cache: pip
 
-      - name: Cache testdata
-        uses: actions/cache@v4
-        with:
-          path: .testdata
-          key: codeentropy-testdata-${{ runner.os }}-py314
+      # Intentionally disabled while debugging CI-only regression flakes.
+      # The old key was static and could restore stale generated test data:
+      # codeentropy-testdata-${{ runner.os }}-py314
+      #
+      # - name: Cache testdata
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: .testdata
+      #     key: codeentropy-testdata-${{ runner.os }}-py314
 
       - name: Install testing dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .[testing]
 
+      - name: Clean local test caches
+        shell: bash
+        run: |
+          rm -rf .pytest_cache
+          rm -rf .testdata
+          find . -type d -name "__pycache__" -prune -exec rm -rf {} +
+
       - name: Run fast regression tests (per system)
         run: |
           python -m pytest tests/regression \
             -m "not slow" \
-            -n auto \
-            --dist=loadscope \
+            --cache-clear \
+            -n 1 \
             -k "${{ matrix.system }}" \
             -vv \
             --durations=20
@@ -200,6 +218,7 @@ jobs:
       - name: Run coverage
         run: |
           pytest tests/unit \
+            --cache-clear \
             --cov CodeEntropy \
             --cov-report term-missing \
             --cov-report xml \

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -91,16 +91,6 @@ jobs:
           python-version: "3.14"
           cache: pip
 
-      # Intentionally disabled while debugging CI-only regression flakes.
-      # The old key was static and could restore stale generated test data:
-      # codeentropy-testdata-${{ runner.os }}-py314
-      #
-      # - name: Cache testdata
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: .testdata
-      #     key: codeentropy-testdata-${{ runner.os }}-py314
-
       - name: Install testing dependencies
         run: |
           python -m pip install --upgrade pip
@@ -111,21 +101,6 @@ jobs:
         run: |
           rm -rf .pytest_cache
           find . -type d -name "__pycache__" -prune -exec rm -rf {} +
-
-      - name: Prepare regression test data
-        shell: bash
-        run: |
-          python -m tests.regression.prepare_testdata --system "${{ matrix.system }}"
-
-          if [ ! -d .testdata ]; then
-            echo ".testdata was not created"
-            exit 1
-          fi
-
-      - name: Snapshot regression test data before tests
-        shell: bash
-        run: |
-          find .testdata -type f -exec sha256sum {} \; | sort > testdata.before.sha256
 
       - name: Run fast regression tests (per system)
         run: |
@@ -138,23 +113,6 @@ jobs:
             --durations=20 \
             --codeentropy-debug
 
-      - name: Snapshot regression test data after tests
-        if: always()
-        shell: bash
-        run: |
-          if [ -d .testdata ]; then
-            find .testdata -type f -exec sha256sum {} \; | sort > testdata.after.sha256
-          else
-            touch testdata.after.sha256
-          fi
-
-      - name: Check regression test data did not change
-        if: always()
-        shell: bash
-        run: |
-          touch testdata.before.sha256 testdata.after.sha256
-          diff -u testdata.before.sha256 testdata.after.sha256
-
       - name: Upload artifacts (failure)
         if: failure()
         uses: actions/upload-artifact@v4
@@ -162,8 +120,6 @@ jobs:
           name: quick-regression-failure-${{ matrix.system }}
           path: |
             .testdata/**
-            testdata.before.sha256
-            testdata.after.sha256
             /tmp/pytest-of-*/pytest-*/**
 
   docs:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -113,6 +113,15 @@ jobs:
           rm -rf .testdata
           find . -type d -name "__pycache__" -prune -exec rm -rf {} +
 
+      - name: Snapshot regression test data before tests
+        shell: bash
+        run: |
+          if [ -d .testdata ]; then
+            find .testdata -type f -exec sha256sum {} \; | sort > testdata.before.sha256
+          else
+            touch testdata.before.sha256
+          fi
+
       - name: Run fast regression tests (per system)
         run: |
           python -m pytest tests/regression \
@@ -123,6 +132,22 @@ jobs:
             -vv \
             --durations=20
 
+      - name: Snapshot regression test data after tests
+        if: always()
+        shell: bash
+        run: |
+          if [ -d .testdata ]; then
+            find .testdata -type f -exec sha256sum {} \; | sort > testdata.after.sha256
+          else
+            touch testdata.after.sha256
+          fi
+
+      - name: Check regression test data did not change
+        if: always()
+        shell: bash
+        run: |
+          diff -u testdata.before.sha256 testdata.after.sha256
+
       - name: Upload artifacts (failure)
         if: failure()
         uses: actions/upload-artifact@v4
@@ -130,6 +155,8 @@ jobs:
           name: quick-regression-failure-${{ matrix.system }}
           path: |
             .testdata/**
+            testdata.before.sha256
+            testdata.after.sha256
             /tmp/pytest-of-*/pytest-*/**
 
   docs:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -110,17 +110,22 @@ jobs:
         shell: bash
         run: |
           rm -rf .pytest_cache
-          rm -rf .testdata
           find . -type d -name "__pycache__" -prune -exec rm -rf {} +
+
+      - name: Prepare regression test data
+        shell: bash
+        run: |
+          python -m tests.regression.prepare_testdata --system "${{ matrix.system }}"
+
+          if [ ! -d .testdata ]; then
+            echo ".testdata was not created"
+            exit 1
+          fi
 
       - name: Snapshot regression test data before tests
         shell: bash
         run: |
-          if [ -d .testdata ]; then
-            find .testdata -type f -exec sha256sum {} \; | sort > testdata.before.sha256
-          else
-            touch testdata.before.sha256
-          fi
+          find .testdata -type f -exec sha256sum {} \; | sort > testdata.before.sha256
 
       - name: Run fast regression tests (per system)
         run: |
@@ -128,19 +133,16 @@ jobs:
             -m "not slow" \
             --cache-clear \
             -n 1 \
-            -k "${{ matrix.system }}" \
+            --system "${{ matrix.system }}" \
             -vv \
-            --durations=20
+            --durations=20 \
+            --codeentropy-debug
 
       - name: Snapshot regression test data after tests
         if: always()
         shell: bash
         run: |
-          if [ -d .testdata ]; then
-            find .testdata -type f -exec sha256sum {} \; | sort > testdata.after.sha256
-          else
-            touch testdata.after.sha256
-          fi
+          find .testdata -type f -exec sha256sum {} \; | sort > testdata.after.sha256
 
       - name: Check regression test data did not change
         if: always()

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -142,12 +142,17 @@ jobs:
         if: always()
         shell: bash
         run: |
-          find .testdata -type f -exec sha256sum {} \; | sort > testdata.after.sha256
+          if [ -d .testdata ]; then
+            find .testdata -type f -exec sha256sum {} \; | sort > testdata.after.sha256
+          else
+            touch testdata.after.sha256
+          fi
 
       - name: Check regression test data did not change
         if: always()
         shell: bash
         run: |
+          touch testdata.before.sha256 testdata.after.sha256
           diff -u testdata.before.sha256 testdata.after.sha256
 
       - name: Upload artifacts (failure)

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -88,7 +88,7 @@ jobs:
       - name: Set up Python 3.14
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
-          python-version: "3.14"
+          python-version: "3.13"
           cache: pip
 
       - name: Install testing dependencies

--- a/tests/regression/conftest.py
+++ b/tests/regression/conftest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import random
 
 import numpy as np
@@ -47,8 +46,6 @@ def pytest_configure(config: pytest.Config) -> None:
     seed = 0
     random.seed(seed)
     np.random.seed(seed)
-
-    os.environ["PYTHONHASHSEED"] = "0"
 
 
 def pytest_collection_modifyitems(

--- a/tests/regression/prepare_testdata.py
+++ b/tests/regression/prepare_testdata.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -12,7 +13,15 @@ from tests.regression.helpers import (
 )
 
 
-def required_paths_for_case(case) -> list[Path]:
+def unwrap_case(case_or_param: Any) -> Any:
+    if hasattr(case_or_param, "values"):
+        values = case_or_param.values
+        if values:
+            return values[0]
+    return case_or_param
+
+
+def required_paths_for_case(case: Any) -> list[Path]:
     raw = yaml.safe_load(case.config_path.read_text())
     cooked = _abspathify_config_paths(raw, base_dir=case.config_path.parent)
 
@@ -37,9 +46,10 @@ def main() -> None:
     args = parser.parse_args()
 
     selected = set(args.system or [])
-    cases = discover_cases()
 
-    for case in cases:
+    for case_or_param in discover_cases():
+        case = unwrap_case(case_or_param)
+
         if selected and case.system not in selected:
             continue
 

--- a/tests/regression/prepare_testdata.py
+++ b/tests/regression/prepare_testdata.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import yaml
+
+from tests.regression.cases import discover_cases
+from tests.regression.helpers import (
+    _abspathify_config_paths,
+    ensure_testdata_for_system,
+)
+
+
+def required_paths_for_case(case) -> list[Path]:
+    raw = yaml.safe_load(case.config_path.read_text())
+    cooked = _abspathify_config_paths(raw, base_dir=case.config_path.parent)
+
+    required: list[Path] = []
+    run1 = cooked.get("run1")
+
+    if isinstance(run1, dict):
+        ff = run1.get("force_file")
+        if isinstance(ff, str) and ff:
+            required.append(Path(ff))
+
+        for p in run1.get("top_traj_file") or []:
+            if isinstance(p, str) and p:
+                required.append(Path(p))
+
+    return required
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--system", action="append", default=None)
+    args = parser.parse_args()
+
+    selected = set(args.system or [])
+    cases = discover_cases()
+
+    for case in cases:
+        if selected and case.system not in selected:
+            continue
+
+        required = required_paths_for_case(case)
+        if required:
+            ensure_testdata_for_system(case.system, required_paths=required)
+
+    print("Regression test data prepared.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
This PR updates the pull request CI workflow to help isolate intermittent CI-only regression failures by removing potentially stale cached regression data, clearing test caches, and standardizing numerical threading settings.

## Changes

### CI environment stabilization:
- Set deterministic numerical threading environment variables across the workflow.
- Set `PYTHONHASHSEED=0` for stable Python hashing behavior.

### Regression cache isolation:
- Temporarily disabled `.testdata` caching for fast regression tests.
- Clear `.pytest_cache`, `.testdata`, and `__pycache__` before regression execution.
- Run pytest with `--cache-clear`.

### Regression execution debugging:
- Temporarily run fast regression tests with `-n 1` to rule out pytest-xdist parallel interference.
- Preserve failure artifact upload for debugging failed regression runs.

## Impact
- Helps determine whether CI flakes are caused by stale cached test data, pytest cache state, parallel test interference, or numerical backend differences.
- Does not change application logic or regression expected values.
- Provides a smaller, safer debugging step before making numerical algorithm changes.