### PR TITLE
Add manual workflow for updating regression baselines

### DIFF
--- a/.github/workflows/update_regression_baselines.yaml
+++ b/.github/workflows/update_regression_baselines.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: pip
 
       - name: Install testing dependencies

--- a/.github/workflows/update_regression_baselines.yaml
+++ b/.github/workflows/update_regression_baselines.yaml
@@ -14,7 +14,7 @@ jobs:
   update-baselines:
     name: Update regression baselines
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - name: Checkout
@@ -33,11 +33,27 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e .[testing]
 
+      - name: Clean regression test data cache
+        run: |
+          rm -rf .testdata
+          rm -rf .pytest_cache
+
       - name: Update regression baselines
-        run: pytest tests/regression --update-baselines
+        run: |
+          python -m pytest tests/regression \
+            --update-baselines \
+            -n 1 \
+            -vv
+
+      - name: Upload updated baselines
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: updated-regression-baselines
+          path: tests/regression/baselines/**
 
       - name: Commit updated baselines
-        uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6
+        uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0
         with:
           commit_message: "test(regression): update baselines"
           commit_user_name: github-actions[bot]

--- a/.github/workflows/update_regression_baselines.yaml
+++ b/.github/workflows/update_regression_baselines.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.14"
+          python-version: "3.13"
           cache: pip
 
       - name: Install testing dependencies

--- a/tests/regression/baselines/benzaldehyde/axes_off.json
+++ b/tests/regression/baselines/benzaldehyde/axes_off.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/benzaldehyde/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/benzaldehyde/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzaldehyde/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzaldehyde/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/benzaldehyde/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzaldehyde/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw0/test_regression_matches_baseli0/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli0/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/benzaldehyde/combined_forcetorque_false.json
+++ b/tests/regression/baselines/benzaldehyde/combined_forcetorque_false.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/benzaldehyde/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/benzaldehyde/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzaldehyde/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzaldehyde/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/benzaldehyde/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzaldehyde/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw0/test_regression_matches_baseli1/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli1/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/benzaldehyde/frame_window.json
+++ b/tests/regression/baselines/benzaldehyde/frame_window.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/benzaldehyde/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/benzaldehyde/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzaldehyde/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzaldehyde/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/benzaldehyde/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzaldehyde/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw1/test_regression_matches_baseli1/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli2/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/benzaldehyde/grouping_each.json
+++ b/tests/regression/baselines/benzaldehyde/grouping_each.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/benzaldehyde/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/benzaldehyde/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzaldehyde/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzaldehyde/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/benzaldehyde/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzaldehyde/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw2/test_regression_matches_baseli0/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli3/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "each",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/benzaldehyde/selection_subset.json
+++ b/tests/regression/baselines/benzaldehyde/selection_subset.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/benzaldehyde/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/benzaldehyde/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzaldehyde/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzaldehyde/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/benzaldehyde/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzaldehyde/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw3/test_regression_matches_baseli0/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli4/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/benzene/axes_off.json
+++ b/tests/regression/baselines/benzene/axes_off.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/benzene/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/benzene/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzene/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzene/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/benzene/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzene/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw3/test_regression_matches_baseli1/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli5/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/benzene/combined_forcetorque_off.json
+++ b/tests/regression/baselines/benzene/combined_forcetorque_off.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/benzene/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/benzene/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzene/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzene/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/benzene/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzene/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw4/test_regression_matches_baseli0/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli6/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/benzene/frame_window.json
+++ b/tests/regression/baselines/benzene/frame_window.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/benzene/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/benzene/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzene/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzene/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/benzene/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzene/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw5/test_regression_matches_baseli0/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli7/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/benzene/grouping_each.json
+++ b/tests/regression/baselines/benzene/grouping_each.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/benzene/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/benzene/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzene/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzene/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/benzene/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzene/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw5/test_regression_matches_baseli1/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli8/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "each",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/benzene/selection_subset.json
+++ b/tests/regression/baselines/benzene/selection_subset.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/benzene/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/benzene/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzene/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzene/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/benzene/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/benzene/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw6/test_regression_matches_baseli1/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli9/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/cyclohexane/axes_off.json
+++ b/tests/regression/baselines/cyclohexane/axes_off.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/cyclohexane/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/cyclohexane/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/cyclohexane/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/cyclohexane/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/cyclohexane/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/cyclohexane/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw7/test_regression_matches_baseli0/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli10/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/cyclohexane/combined_forcetorque_off.json
+++ b/tests/regression/baselines/cyclohexane/combined_forcetorque_off.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/cyclohexane/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/cyclohexane/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/cyclohexane/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/cyclohexane/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/cyclohexane/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/cyclohexane/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw7/test_regression_matches_baseli1/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli11/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/cyclohexane/frame_window.json
+++ b/tests/regression/baselines/cyclohexane/frame_window.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/cyclohexane/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/cyclohexane/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/cyclohexane/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/cyclohexane/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/cyclohexane/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/cyclohexane/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw8/test_regression_matches_baseli1/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli12/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/cyclohexane/grouping_each.json
+++ b/tests/regression/baselines/cyclohexane/grouping_each.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/cyclohexane/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/cyclohexane/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/cyclohexane/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/cyclohexane/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/cyclohexane/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/cyclohexane/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw9/test_regression_matches_baseli0/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli13/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "each",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/cyclohexane/selection_subset.json
+++ b/tests/regression/baselines/cyclohexane/selection_subset.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/cyclohexane/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/cyclohexane/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/cyclohexane/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/cyclohexane/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/cyclohexane/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/cyclohexane/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw10/test_regression_matches_baseli0/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli14/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/dna/axes_off.json
+++ b/tests/regression/baselines/dna/axes_off.json
@@ -1,8 +1,8 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/dna/md_A4_dna.tpr",
-      "/home/ogo12949/CodeEntropy/.testdata/dna/md_A4_dna_xf.trr"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/dna/md_A4_dna.tpr",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/dna/md_A4_dna_xf.trr"
     ],
     "force_file": null,
     "file_format": null,
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw10/test_regression_matches_baseli1/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli15/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "RAD"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/dna/combined_forcetorque_off.json
+++ b/tests/regression/baselines/dna/combined_forcetorque_off.json
@@ -1,8 +1,8 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/dna/md_A4_dna.tpr",
-      "/home/ogo12949/CodeEntropy/.testdata/dna/md_A4_dna_xf.trr"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/dna/md_A4_dna.tpr",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/dna/md_A4_dna_xf.trr"
     ],
     "force_file": null,
     "file_format": null,
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw12/test_regression_matches_baseli0/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli16/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "RAD"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/dna/frame_window.json
+++ b/tests/regression/baselines/dna/frame_window.json
@@ -1,8 +1,8 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/dna/md_A4_dna.tpr",
-      "/home/ogo12949/CodeEntropy/.testdata/dna/md_A4_dna_xf.trr"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/dna/md_A4_dna.tpr",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/dna/md_A4_dna_xf.trr"
     ],
     "force_file": null,
     "file_format": null,
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw11/test_regression_matches_baseli0/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli17/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "RAD"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/dna/grouping_each.json
+++ b/tests/regression/baselines/dna/grouping_each.json
@@ -1,8 +1,8 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/dna/md_A4_dna.tpr",
-      "/home/ogo12949/CodeEntropy/.testdata/dna/md_A4_dna_xf.trr"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/dna/md_A4_dna.tpr",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/dna/md_A4_dna_xf.trr"
     ],
     "force_file": null,
     "file_format": null,
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw11/test_regression_matches_baseli1/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli18/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "each",
@@ -23,10 +23,10 @@
     "search_type": "RAD"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/dna/selection_subset.json
+++ b/tests/regression/baselines/dna/selection_subset.json
@@ -1,8 +1,8 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/dna/md_A4_dna.tpr",
-      "/home/ogo12949/CodeEntropy/.testdata/dna/md_A4_dna_xf.trr"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/dna/md_A4_dna.tpr",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/dna/md_A4_dna_xf.trr"
     ],
     "force_file": null,
     "file_format": null,
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw13/test_regression_matches_baseli0/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli19/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "RAD"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/ethyl-acetate/axes_off.json
+++ b/tests/regression/baselines/ethyl-acetate/axes_off.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/ethyl-acetate/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/ethyl-acetate/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/ethyl-acetate/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/ethyl-acetate/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/ethyl-acetate/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/ethyl-acetate/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw13/test_regression_matches_baseli1/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli20/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/ethyl-acetate/combined_forcetorque_off.json
+++ b/tests/regression/baselines/ethyl-acetate/combined_forcetorque_off.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/ethyl-acetate/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/ethyl-acetate/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/ethyl-acetate/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/ethyl-acetate/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/ethyl-acetate/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/ethyl-acetate/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw14/test_regression_matches_baseli0/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli21/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/ethyl-acetate/frame_window.json
+++ b/tests/regression/baselines/ethyl-acetate/frame_window.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/ethyl-acetate/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/ethyl-acetate/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/ethyl-acetate/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/ethyl-acetate/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/ethyl-acetate/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/ethyl-acetate/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw15/test_regression_matches_baseli0/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli22/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/ethyl-acetate/grouping_each.json
+++ b/tests/regression/baselines/ethyl-acetate/grouping_each.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/ethyl-acetate/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/ethyl-acetate/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/ethyl-acetate/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/ethyl-acetate/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/ethyl-acetate/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/ethyl-acetate/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw15/test_regression_matches_baseli1/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli23/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "each",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/ethyl-acetate/selection_subset.json
+++ b/tests/regression/baselines/ethyl-acetate/selection_subset.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/ethyl-acetate/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/ethyl-acetate/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/ethyl-acetate/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/ethyl-acetate/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/ethyl-acetate/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/ethyl-acetate/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw13/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli24/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/methane/axes_off.json
+++ b/tests/regression/baselines/methane/axes_off.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/methane/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/methane/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methane/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methane/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/methane/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methane/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 112.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw11/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli25/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/methane/combined_forcetorque_off.json
+++ b/tests/regression/baselines/methane/combined_forcetorque_off.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/methane/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/methane/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methane/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methane/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/methane/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methane/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 112.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw12/test_regression_matches_baseli3/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli26/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/methane/frame_window.json
+++ b/tests/regression/baselines/methane/frame_window.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/methane/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/methane/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methane/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methane/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/methane/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methane/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 112.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw4/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli27/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/methane/grouping_each.json
+++ b/tests/regression/baselines/methane/grouping_each.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/methane/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/methane/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methane/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methane/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/methane/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methane/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 112.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw15/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli28/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "each",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/methane/selection_subset.json
+++ b/tests/regression/baselines/methane/selection_subset.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/methane/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/methane/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methane/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methane/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/methane/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methane/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 112.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw3/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli29/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/methanol/axes_off.json
+++ b/tests/regression/baselines/methanol/axes_off.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/methanol/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/methanol/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methanol/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methanol/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/methanol/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methanol/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw5/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli30/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/methanol/combined_forcetorque_off.json
+++ b/tests/regression/baselines/methanol/combined_forcetorque_off.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/methanol/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/methanol/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methanol/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methanol/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/methanol/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methanol/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw14/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli31/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/methanol/frame_window.json
+++ b/tests/regression/baselines/methanol/frame_window.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/methanol/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/methanol/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methanol/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methanol/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/methanol/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methanol/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw7/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli32/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/methanol/grouping_each.json
+++ b/tests/regression/baselines/methanol/grouping_each.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/methanol/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/methanol/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methanol/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methanol/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/methanol/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methanol/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw9/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli33/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "each",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/methanol/selection_subset.json
+++ b/tests/regression/baselines/methanol/selection_subset.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/methanol/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/methanol/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methanol/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methanol/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/methanol/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/methanol/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw10/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli34/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/octonol/axes_off.json
+++ b/tests/regression/baselines/octonol/axes_off.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/octonol/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/octonol/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/octonol/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/octonol/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/octonol/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/octonol/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw11/test_regression_matches_baseli4/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli35/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/octonol/combined_forcetorque_off.json
+++ b/tests/regression/baselines/octonol/combined_forcetorque_off.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/octonol/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/octonol/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/octonol/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/octonol/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/octonol/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/octonol/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw10/test_regression_matches_baseli3/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli36/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/octonol/frame_window.json
+++ b/tests/regression/baselines/octonol/frame_window.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/octonol/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/octonol/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/octonol/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/octonol/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/octonol/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/octonol/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw0/test_regression_matches_baseli3/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli37/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/octonol/grouping_each.json
+++ b/tests/regression/baselines/octonol/grouping_each.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/octonol/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/octonol/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/octonol/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/octonol/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/octonol/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/octonol/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw5/test_regression_matches_baseli3/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli38/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "each",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/octonol/selection_subset.json
+++ b/tests/regression/baselines/octonol/selection_subset.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/octonol/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/octonol/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/octonol/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/octonol/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/octonol/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/octonol/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw10/test_regression_matches_baseli4/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli39/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/water/axes_off.json
+++ b/tests/regression/baselines/water/axes_off.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/water/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/water/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/water/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/water/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/water/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/water/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw3/test_regression_matches_baseli4/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli40/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/water/combined_forcetorque_off.json
+++ b/tests/regression/baselines/water/combined_forcetorque_off.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/water/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/water/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/water/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/water/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/water/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/water/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw13/test_regression_matches_baseli4/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli41/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/water/frame_window.json
+++ b/tests/regression/baselines/water/frame_window.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/water/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/water/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/water/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/water/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/water/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/water/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw15/test_regression_matches_baseli4/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli42/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/water/grouping_each.json
+++ b/tests/regression/baselines/water/grouping_each.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/water/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/water/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/water/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/water/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/water/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/water/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw7/test_regression_matches_baseli3/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli43/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "each",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/water/selection_subset.json
+++ b/tests/regression/baselines/water/selection_subset.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/water/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/water/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/water/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/water/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/water/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/water/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw6/test_regression_matches_baseli2/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli44/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": true,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {

--- a/tests/regression/baselines/water/water_off.json
+++ b/tests/regression/baselines/water/water_off.json
@@ -1,10 +1,10 @@
 {
   "args": {
     "top_traj_file": [
-      "/home/ogo12949/CodeEntropy/.testdata/water/molecules.top",
-      "/home/ogo12949/CodeEntropy/.testdata/water/trajectory.crd"
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/water/molecules.top",
+      "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/water/trajectory.crd"
     ],
-    "force_file": "/home/ogo12949/CodeEntropy/.testdata/water/forces.frc",
+    "force_file": "/home/runner/work/CodeEntropy/CodeEntropy/.testdata/water/forces.frc",
     "file_format": "MDCRD",
     "kcal_force_units": true,
     "selection_string": "resid 1:10",
@@ -14,7 +14,7 @@
     "bin_width": 30,
     "temperature": 298.0,
     "verbose": false,
-    "output_file": "/tmp/pytest-of-ogo12949/pytest-3/popen-gw7/test_regression_matches_baseli4/job001/output_file.json",
+    "output_file": "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_regression_matches_baseli45/job001/output_file.json",
     "force_partitioning": 0.5,
     "water_entropy": false,
     "grouping": "molecules",
@@ -23,10 +23,10 @@
     "search_type": "grid"
   },
   "provenance": {
-    "python": "3.13.5",
-    "platform": "Linux-6.17.0-1017-oem-x86_64-with-glibc2.39",
-    "codeentropy_version": "2.1.1",
-    "git_sha": "f2e0e7c509c6683eea94dd25a25bba2639c0bb96"
+    "python": "3.14.4",
+    "platform": "Linux-6.17.0-1010-azure-x86_64-with-glibc2.39",
+    "codeentropy_version": "2.2.2",
+    "git_sha": "3553bbfcbebe9e626f13c1c8c5652450cc440011"
   },
   "groups": {
     "0": {


### PR DESCRIPTION
## Summary
This PR will add a manually triggered GitHub Actions workflow for regenerating regression baselines in a controlled CI environment using Python 3.13.

## Changes

### Standardize baseline generation environment
- Pin baseline generation to Python 3.13
- Configure a consistent CI environment for regression baseline updates

## Impact
- Provides a reproducible workflow for refreshing regression baselines
- Reduces environment-related baseline inconsistencies
- Keeps regression baseline updates controlled and reviewable