### PR TITLE
Disable GitHub Actions Caching Across CI Workflows

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
 
       - name: Install testing dependencies
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
 
       - name: Install testing dependencies
         run: |
@@ -50,7 +49,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.14"
-          cache: pip
 
       - name: Install testing dependencies
         run: |
@@ -82,13 +80,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.14"
-          cache: pip
-
-      - name: Cache testdata
-        uses: actions/cache@v4
-        with:
-          path: .testdata
-          key: codeentropy-testdata-${{ runner.os }}-py314
 
       - name: Install testing dependencies
         run: |
@@ -128,7 +119,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.14"
-          cache: pip
 
       - name: Install docs dependencies
         run: |
@@ -160,7 +150,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.14"
-          cache: pip
 
       - name: Install pre-commit dependencies
         run: |
@@ -190,7 +179,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.14"
-          cache: pip
 
       - name: Install testing dependencies
         run: |

--- a/.github/workflows/update_regression_baselines.yaml
+++ b/.github/workflows/update_regression_baselines.yaml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
-          cache: pip
 
       - name: Install testing dependencies
         run: |

--- a/.github/workflows/weekly-docs.yaml
+++ b/.github/workflows/weekly-docs.yaml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
 
       - name: Install python dependencies
         run: |

--- a/.github/workflows/weekly-regression.yaml
+++ b/.github/workflows/weekly-regression.yaml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.14"
-          cache: pip
 
       - name: Install testing dependencies
         run: |
@@ -57,13 +56,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.14"
-          cache: pip
-
-      - name: Cache regression test data
-        uses: actions/cache@v4
-        with:
-          path: .testdata
-          key: codeentropy-testdata-${{ runner.os }}-py314
 
       - name: Install testing dependencies
         run: |


### PR DESCRIPTION
## Summary
This PR will disable all explicit caching in the GitHub Actions workflows to ensure every CI and regression run executes in a completely fresh environment.

## Changes

### Remove pip caching from setup-python
- Removed `cache: pip` from all `actions/setup-python` steps.
- Ensures Python dependencies are freshly installed on every workflow run.
- Prevents reuse of cached wheels and virtual environment artifacts between runs.

### Remove regression test data caching
- Removed the `actions/cache@v4` step for `.testdata`.
- Ensures regression test data is regenerated or freshly downloaded every run.
- Prevents stale regression data from persisting between CI executions.

## Impact
- CI runs will take longer due to fresh dependency installation.
- Regression workflows will no longer reuse cached `.testdata`.
- Workflow behaviour becomes more deterministic and reproducible.
- Eliminates potential issues caused by stale or corrupted caches.