### PR TITLE
Fix indexing issue for multiple dihedrals

### DIFF
--- a/CodeEntropy/levels/dihedrals.py
+++ b/CodeEntropy/levels/dihedrals.py
@@ -219,7 +219,9 @@ class ConformationStateBuilder:
         Returns:
             List of peaks per dihedral (peak_values[dihedral_index] -> list of peaks).
         """
-        rep_mol = self._universe_operations.extract_fragment(data_container, 0)
+        rep_mol = self._universe_operations.extract_fragment(
+            data_container, molecules[0]
+        )
         number_frames = len(rep_mol.trajectory)
         num_residues = len(rep_mol.residues)
 
@@ -421,7 +423,9 @@ class ConformationStateBuilder:
         Returns:
             List of state labels (strings).
         """
-        rep_mol = self._universe_operations.extract_fragment(data_container, 0)
+        rep_mol = self._universe_operations.extract_fragment(
+            data_container, molecules[0]
+        )
         number_frames = len(rep_mol.trajectory)
         num_residues = len(rep_mol.residues)
 


### PR DESCRIPTION
## Summary
For systems with two or more groups of molecules, there was an indexing error when looping over residues for the united atom level calculation it was using the first molecule of the system to count the number of residues instead of the first molecule of the group.

## Changes
- in dihedrals.py, change rep_mol index from 0 to molecules[0]

## Impact
- Should now not have out of index errors when the system contains molecules with different numbers of residues.
