### PR TITLE
Store grouped-only regression baselines and run slow cases in update workflow

### DIFF
--- a/.github/workflows/update_regression_baselines.yaml
+++ b/.github/workflows/update_regression_baselines.yaml
@@ -33,7 +33,7 @@ jobs:
           python -m pip install -e .[testing]
 
       - name: Update regression baselines
-        run: pytest tests/regression --update-baselines
+        run: pytest tests/regression --update-baselines --run-slow
 
       - name: Commit updated baselines
         uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6

--- a/tests/regression/test_regression.py
+++ b/tests/regression/test_regression.py
@@ -51,6 +51,18 @@ def _group_index(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return groups
 
 
+def _baseline_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """
+    Build the persisted regression baseline payload.
+
+    Baselines intentionally store only grouped entropy results, not runtime
+    arguments or provenance, so they remain stable across machines and runs.
+    """
+    return {
+        "groups": _group_index(payload),
+    }
+
+
 def _compare_grouped(
     *,
     got_payload: dict[str, Any],
@@ -148,7 +160,8 @@ def test_regression_matches_baseline(
         options.
 
     Raises:
-        AssertionError: If the output does not match the baseline or baseline is missing
+        AssertionError: If the output does not match the baseline or
+        baseline is missing.
     """
     system = case.system
     config_path = case.config_path
@@ -176,7 +189,9 @@ def test_regression_matches_baseline(
 
     if request.config.getoption("--update-baselines"):
         baseline_path.parent.mkdir(parents=True, exist_ok=True)
-        baseline_path.write_text(json.dumps(run.payload, indent=2))
+        baseline_path.write_text(
+            json.dumps(_baseline_payload(run.payload), indent=2) + "\n"
+        )
         pytest.skip(f"Updated baseline for {system}")
 
     _compare_grouped(


### PR DESCRIPTION
## Summary

This PR updates the regression baseline workflow so that regenerated baselines only store the grouped result data used by the regression comparison.

It also updates the GitHub workflow for baseline regeneration to include `--run-slow`, ensuring slow regression cases are included when updating stored baselines.

## Changes

### Regression baseline output

- Added a baseline payload helper to persist only the `groups` section of the CodeEntropy output.
- Removed runtime arguments and provenance metadata from regenerated baseline files.
- Keeps normal CodeEntropy output unchanged for users.
- Keeps regression comparison focused on the grouped entropy values that are actually tested.

### GitHub baseline update workflow

- Added `--run-slow` to the baseline update command.
- Ensures slow-marked regression tests are included when regenerating baselines in CI.
- Avoids accidentally updating only the faster subset of regression baselines.

## Impact

- Regression baseline files are cleaner and more stable.
- Machine-specific data such as temporary paths, Python versions, platform details, and Git SHAs will no longer be committed in updated baselines.
- CI baseline updates now cover the full intended regression suite, including slow cases.
- User-facing JSON output is unaffected.