### PR TITLE
Update Windows runner to VS2026 image

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-15, windows-2025]
+        os: [ubuntu-24.04, macos-15, windows-2025-vs2026]
         python-version: ["3.12", "3.13", "3.14"]
 
     steps:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-15, windows-2025]
+        os: [ubuntu-24.04, macos-15, windows-2025-vs2026]
         python-version: ["3.12", "3.13", "3.14"]
 
     steps:

--- a/.github/workflows/weekly-docs.yaml
+++ b/.github/workflows/weekly-docs.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-2025, macos-15]
+        os: [ubuntu-24.04, windows-2025-vs2026, macos-15]
         python-version: ["3.12", "3.13", "3.14"]
     timeout-minutes: 30
 


### PR DESCRIPTION
## Summary
This PR updates the Windows CI runner image to explicitly use the Visual Studio 2026 image.

## Changes
### Update Windows CI runner image:
- Updated the Windows workflow runner from `windows-2025` to `windows-2025-vs2026`.
- Made the CI configuration explicit instead of relying on the automatic redirect from `windows-2025`.
- Ensured the workflow uses the intended Windows Server 2025 image with Visual Studio 2026 support.

## Impact
- Improves clarity in the CI workflow configuration.
- Avoids relying on GitHub Actions runner image redirects.
- Helps prevent unexpected CI behaviour when the default Windows runner image changes.
