### PR TITLE
Update macOS runner to macos-26

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-15, windows-2025]
+        os: [ubuntu-24.04, macos-26, windows-2025]
         python-version: ["3.12", "3.13", "3.14"]
 
     steps:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-15, windows-2025]
+        os: [ubuntu-24.04, macos-26, windows-2025]
         python-version: ["3.12", "3.13", "3.14"]
 
     steps:

--- a/.github/workflows/weekly-docs.yaml
+++ b/.github/workflows/weekly-docs.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-2025, macos-15]
+        os: [ubuntu-24.04, windows-2025, macos-26]
         python-version: ["3.12", "3.13", "3.14"]
     timeout-minutes: 30
 


### PR DESCRIPTION
## Summary
This PR updates the macOS CI runner image from `macos-15` to `macos-26`.

## Changes
### Update macOS CI runner image:
- Updated the macOS workflow runner from `macos-15` to `macos-26`.
- Ensured the CI workflow uses the newer macOS 26 runner image.
- Aligned the macOS CI environment with the updated GitHub Actions runner image.

## Impact
- Keeps the macOS CI environment up to date.
- Helps identify compatibility issues with macOS 26 earlier.
- Reduces reliance on the older macOS 15 runner image.