### PR TITLE
Run Coveralls coverage on pull requests and main branch updates

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -46,6 +46,7 @@ jobs:
   discover-systems:
     name: Discover regression systems
     if: github.event_name == 'pull_request'
+    needs: [docs, pre-commit, coverage]
     runs-on: ubuntu-24.04
     outputs:
       systems: ${{ steps.set-systems.outputs.systems }}
@@ -73,7 +74,7 @@ jobs:
   regression-quick:
     name: Regression (fast) • ${{ matrix.system }}
     if: github.event_name == 'pull_request'
-    needs: [unit, discover-systems]
+    needs: discover-systems
     runs-on: ubuntu-24.04
     timeout-minutes: 35
 
@@ -151,6 +152,7 @@ jobs:
   pre-commit:
     name: Pre-commit
     if: github.event_name == 'pull_request'
+    needs: unit
     runs-on: ubuntu-24.04
     timeout-minutes: 15
 
@@ -179,6 +181,7 @@ jobs:
 
   coverage:
     name: Coverage
+    needs: unit
     runs-on: ubuntu-24.04
     timeout-minutes: 30
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -46,7 +46,6 @@ jobs:
   discover-systems:
     name: Discover regression systems
     if: github.event_name == 'pull_request'
-    needs: [docs, pre-commit, coverage]
     runs-on: ubuntu-24.04
     outputs:
       systems: ${{ steps.set-systems.outputs.systems }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,6 +2,13 @@ name: Pull Request CI
 
 on:
   pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
 
 concurrency:
   group: pr-${{ github.ref }}
@@ -10,6 +17,7 @@ concurrency:
 jobs:
   unit:
     name: Unit
+    if: github.event_name == 'pull_request'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
     strategy:
@@ -37,6 +45,7 @@ jobs:
 
   discover-systems:
     name: Discover regression systems
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     outputs:
       systems: ${{ steps.set-systems.outputs.systems }}
@@ -63,6 +72,7 @@ jobs:
 
   regression-quick:
     name: Regression (fast) • ${{ matrix.system }}
+    if: github.event_name == 'pull_request'
     needs: [unit, discover-systems]
     runs-on: ubuntu-24.04
     timeout-minutes: 35
@@ -86,7 +96,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e .[testing]
 
-      - name: Run fast regression tests (per system)
+      - name: Run fast regression tests
         run: |
           python -m pytest tests/regression \
             -m "not slow" \
@@ -96,7 +106,7 @@ jobs:
             -vv \
             --durations=20
 
-      - name: Upload artifacts (failure)
+      - name: Upload artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
@@ -107,6 +117,7 @@ jobs:
 
   docs:
     name: Docs
+    if: github.event_name == 'pull_request'
     needs: unit
     runs-on: ubuntu-24.04
     timeout-minutes: 25
@@ -139,6 +150,7 @@ jobs:
 
   pre-commit:
     name: Pre-commit
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
 
@@ -167,7 +179,6 @@ jobs:
 
   coverage:
     name: Coverage
-    needs: unit
     runs-on: ubuntu-24.04
     timeout-minutes: 30
 
@@ -187,7 +198,7 @@ jobs:
 
       - name: Run coverage
         run: |
-          pytest tests/unit \
+          python -m pytest tests/unit \
             --cov CodeEntropy \
             --cov-report term-missing \
             --cov-report xml \


### PR DESCRIPTION
## Summary
This PR updates the pull request CI workflow so that full CI continues to run for pull requests, while coverage is also run on pushes to `main` to keep the Coveralls base branch coverage up to date.

## Changes
### Update GitHub Actions coverage workflow:
- Keep the workflow triggered for all pull requests.
- Keep the workflow triggered on pushes to `main`.
- Restrict the main CI jobs, including unit tests, regression tests, documentation, and pre-commit checks, to pull request events only.
- Allow the coverage job to run on both pull requests and pushes to `main`.
- Remove the coverage job dependency on the unit-test matrix so that coverage can still run when only the `main` push event is triggered.
- Add explicit workflow permissions for reading repository contents and publishing checks/PR coverage information.

## Impact
- Full CI remains active for pull requests across all target branches.
- Pushes to `main` no longer rerun the full test suite unnecessarily.
- Coveralls receives updated coverage data from `main`, ensuring PR coverage comparisons use the latest base branch.
- Coverage differences in pull requests should be reported more consistently and reliably.