### PR TITLE
Fix blocked Coveralls upload by splitting main coverage workflow

### DIFF
--- a/.github/workflows/coveralls-main.yaml
+++ b/.github/workflows/coveralls-main.yaml
@@ -1,0 +1,54 @@
+name: Coveralls Main
+
+on:
+  push:
+    branches: [main]
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coveralls-main-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coveralls:
+    name: Build main coverage baseline
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    permissions:
+      contents: read
+      checks: write
+      statuses: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.14"
+
+      - name: Install testing dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[testing]
+
+      - name: Run coverage
+        run: |
+          python -m pytest tests/unit \
+            --cov CodeEntropy \
+            --cov-report term-missing \
+            --cov-report xml \
+            -q
+
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: coverage.xml
+          fail-on-error: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,22 +2,17 @@ name: Pull Request CI
 
 on:
   pull_request:
-  push:
-    branches: [main]
 
 permissions:
   contents: read
-  checks: write
-  pull-requests: write
 
 concurrency:
-  group: pr-${{ github.ref }}
+  group: pr-ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   unit:
     name: Unit
-    if: github.event_name == 'pull_request'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
     strategy:
@@ -40,12 +35,11 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e .[testing]
 
-      - name: Pytest (unit) • ${{ matrix.os }}, ${{ matrix.python-version }}
+      - name: Pytest unit • ${{ matrix.os }}, ${{ matrix.python-version }}
         run: python -m pytest tests/unit
 
   discover-systems:
     name: Discover regression systems
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     outputs:
       systems: ${{ steps.set-systems.outputs.systems }}
@@ -68,11 +62,10 @@ jobs:
         id: set-systems
         run: |
           SYSTEMS=$(python -m tests.regression.list_systems)
-          echo "systems=$SYSTEMS" >> $GITHUB_OUTPUT
+          echo "systems=$SYSTEMS" >> "$GITHUB_OUTPUT"
 
   regression-quick:
-    name: Regression (fast) • ${{ matrix.system }}
-    if: github.event_name == 'pull_request'
+    name: Regression fast • ${{ matrix.system }}
     needs: discover-systems
     runs-on: ubuntu-24.04
     timeout-minutes: 35
@@ -117,7 +110,6 @@ jobs:
 
   docs:
     name: Docs
-    if: github.event_name == 'pull_request'
     needs: unit
     runs-on: ubuntu-24.04
     timeout-minutes: 25
@@ -150,7 +142,6 @@ jobs:
 
   pre-commit:
     name: Pre-commit
-    if: github.event_name == 'pull_request'
     needs: unit
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -183,6 +174,12 @@ jobs:
     needs: unit
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+
+    permissions:
+      contents: read
+      checks: write
+      statuses: write
+      pull-requests: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
This PR separates pull request validation from the Coveralls baseline upload workflow. The previous workflow attempted to support both PR checks and `push` to `main` coverage uploads in the same file, but the Coveralls upload was still blocked because it depended on PR-only jobs.

## Changes
### Split PR CI and Coveralls workflows:
* Replaced the combined PR/push workflow with two separate workflows:
  * Pull request CI for tests, docs, pre-commit, regression checks, and PR coverage reporting.
  * Coveralls Main for rebuilding the main branch coverage baseline on `push` to `main`.
* Removed the `push` trigger from the PR CI workflow.
* Added a dedicated `coveralls-main.yaml` workflow that runs independently on pushes to `main`.
* Added manual `workflow_dispatch` support so the Coveralls baseline can be rebuilt manually when required.

### Restore Coveralls coverage reporting:
* Keeps PR coverage uploads to Coveralls so coverage changes can be checked during review.
* Adds a dedicated main branch Coveralls upload to maintain the baseline used for PR coverage comparisons.
* Keeps coverage generation through `pytest-cov` and `coverage.xml`.

## Impact
* Restores Coveralls uploads on `push` to `main`.
* Ensures the main branch coverage baseline is rebuilt after merges.
* Allows PRs to be checked against the latest main coverage baseline.
* Avoids skipped-job dependency issues caused by mixing PR-only and push-to-main logic in one workflow.