### PR TITLE
fix file-store paths to new domain path

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -515,7 +515,7 @@ Example 1: DNA Fragment (Smallest / Fastest)
 
 Data files:
 
-`DNA fragment example (~1MB) <https://ccpbiosim.ac.uk/file-store/codeentropy-examples/dna_example.tar>`_
+`DNA fragment example (~1MB) <https://file-store.ccpbiosim.org/codeentropy-examples/dna_example.tar>`_
 
 Create or edit ``config.yaml`` in your working directory:
 
@@ -551,7 +551,7 @@ Example 2: Lysozyme (Larger / Slower)
 
 Data files:
 
-`Lysozyme example (~1.2GB) <https://ccpbiosim.ac.uk/file-store/codeentropy-examples/lysozyme_example.tar>`_
+`Lysozyme example (~1.2GB) <https://file-store.ccpbiosim.org/codeentropy-examples/lysozyme_example.tar>`_
 
 Create or edit ``config.yaml`` in your working directory:
 

--- a/tests/regression/helpers.py
+++ b/tests/regression/helpers.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import yaml
 
-DEFAULT_TESTDATA_BASE_URL = "https://www.ccpbiosim.ac.uk/file-store/codeentropy-testing"
+DEFAULT_TESTDATA_BASE_URL = "https://file-store.ccpbiosim.org/codeentropy-testing"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
Updates paths to new org domain with file-store on full sub-domain path.

## Changes
- Updated paths in documentation for downloading examples
- Updated base path for regression tests.

## Impact
Main impact is the continued working of the CI and users able to download files from the new ccpbiosim.org path instead of ccpbiosim.ac.uk. This means when we eventually lapse the ac.uk domains there isn't a nasty surprise waiting for us in software repos. Doing this now also avoids sending users through a 301 redirect on DNS.
