### PR TITLE
Enable GitHub Actions Updates in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
     "group:monorepos",
     "group:recommended"
   ],
-  "enabledManagers": ["pep621"],
+  "enabledManagers": ["pep621", "github-actions"],
   "pep621": {
     "enabled": true
   },


### PR DESCRIPTION
## Summary
Updates the custom Renovate configuration to include GitHub Actions dependencies alongside the existing Python dependency management.

## Changes
### Enable GitHub Actions Manager
* Added `github-actions` to the `enabledManagers` configuration.
* Retained the existing `pep621` manager for Python dependencies.

## Impact
* Allows Renovate to detect and propose updates for actions used in GitHub Actions workflows.
* Expands automated dependency management beyond Python dependencies without changing any existing Renovate behaviour.