### PR TITLE
Introduce Bonded Residue Rotation Axes / UA Translation Axes

### DIFF
--- a/CodeEntropy/levels/axes.py
+++ b/CodeEntropy/levels/axes.py
@@ -230,7 +230,6 @@ class AxesCalculator:
             if box is not None
             else np.asarray(u.dimensions[:3], dtype=float)
         )
-
         center = residue_atoms.center_of_mass(unwrap=True)
 
         if not topology.has_neighbor_bonds:
@@ -573,6 +572,53 @@ class AxesCalculator:
         )
 
         return custom_axes, custom_moment_of_inertia
+
+    def get_residue_custom_axes(self, edges, center):
+        """
+        Compute rotation axes at the residue level, given
+        two edge atoms of the residue (E1+E2),
+        and the centre of geometry of backbone atoms
+        that are not edges (C).
+        x axis is O-E1
+        y axis is O-C (perpendicular to O-E1 in the
+        same plane as E2)
+        z axis is perpendicular to the two other axes
+
+        ::
+
+                    C
+                    |
+                    |
+            E1 ---- O --- E2
+
+        Args:
+            edges: (2,3) positions of two edge atoms
+            center: (3,) coordinates of the inner backbone
+            centre of geometry
+
+        Returns:
+            rot_center: (3,) rotation centre,
+            lies on the E1-E2 vector
+            rot_axes: (3,3) rotation axes of residue
+        """
+        # x axis is O-E1
+        E1C_vector = center - edges[0].position
+        # look for projection of E1-O onto E1-E2 (E1-C)
+        E1E2_vector = edges[1].position - edges[0].position
+        E1O_vector = (
+            np.dot(E1E2_vector, E1C_vector) / (np.linalg.norm(E1E2_vector) ** 2)
+        ) * E1E2_vector
+        x_axis = -E1O_vector
+        # O-C = O-E1 + E1-C
+        OC_vector = -E1O_vector + E1C_vector
+        y_axis = OC_vector
+        z_axis = np.cross(x_axis, y_axis)
+        x_axis /= np.linalg.norm(x_axis)
+        y_axis /= np.linalg.norm(y_axis)
+        z_axis /= np.linalg.norm(z_axis)
+        rot_axes = np.array([x_axis, y_axis, z_axis])
+        rot_center = E1O_vector + edges[0].position
+        return rot_center, rot_axes
 
     def get_bonded_axes(self, system, atom, dimensions: np.ndarray):
         r"""Compute UA rotational axes from bonded topology around a heavy atom.

--- a/CodeEntropy/levels/axes.py
+++ b/CodeEntropy/levels/axes.py
@@ -78,10 +78,13 @@ class AxesCalculator:
             * Set translational axes equal to rotational axes (as per the original
               code convention).
         - If bonded to other residues:
+            Translational axes are principal axes of data_container.
             Find edge heavy atoms (i.e. heavy atoms bonded to neighbour residues)
             and find the shortest chain between them: the backbone. Edge
-            atoms + backbone COM are used to determine UA translational axes
+            atoms + backbone COM are used to determine residue rotational axes.
             (see get_residue_custom_axes)
+        Compute a custom MOI, using heavy atom positions and heavy atom+ hydrogen
+        masses.
 
         Args:
             data_container (MDAnalysis.Universe or AtomGroup):
@@ -107,7 +110,6 @@ class AxesCalculator:
                 If the residue selection is empty.
         """
         # TODO refine selection so that it will work for branched polymers
-        # match indexing to MDAnalysis indexing
 
         index_prev = index + relative_index - 1
         index_next = index + relative_index + 1
@@ -130,10 +132,6 @@ class AxesCalculator:
         ua_masses = self.get_UA_masses(residue)
 
         if len(edge_atom_set) == 0:
-            # No UAS are bonded to other residues
-            # Use a custom principal axes, from a MOI tensor that uses positions of
-            # heavy atoms only, but including masses of heavy atom + bonded H.
-
             moi_tensor = self.get_moment_of_inertia_tensor(
                 center_of_mass=np.array(residue.center_of_mass()),
                 positions=uas.positions,
@@ -144,24 +142,20 @@ class AxesCalculator:
             trans_axes = rot_axes  # per original convention
             rot_center = np.array(residue.center_of_mass())
         else:
-            # If bonded to other residues, use local axes.
             make_whole(data_container.atoms)
             trans_axes = data_container.atoms.principal_axes()
 
             if len(edge_atom_set) == 1:
                 if index == 0:
-                    # first residue
-                    # use first heavy atom
+                    # first residue: use first heavy atom
                     edges = [residue.atoms[0], edge_atom_set[0]]
                     backbone = self.get_chain(
                         residue, residue.atoms[0], edge_atom_set[0]
                     )
                 else:
-                    # last residue
+                    # last residue: last heavy atom
                     last_index = len(uas) - 1
                     last = None
-                    # look for last heavy atom
-                    # with only one bond to another
                     if last_index > 0 and last is None:
                         heavy_atom = uas[last_index]
                         last = heavy_atom
@@ -169,11 +163,8 @@ class AxesCalculator:
 
                     backbone = self.get_chain(residue, edge_atom_set[0], last)
             else:
-                # residue has two bonds to other residues
                 edges = [edge_atom_set[0], edge_atom_set[1]]
                 backbone = self.get_chain(residue, edge_atom_set[0], edge_atom_set[1])
-            # get edge atoms of the residue
-            # for terminal residues, this will include the C/N terminus
             backbone_center = np.zeros(3)
             for heavy_atom in backbone:
                 backbone_center += heavy_atom.position
@@ -256,18 +247,19 @@ class AxesCalculator:
         - Translational axes:
             Use the same approach as residue level rotational.
             Identify residue of interest and neighbours, then select
-            edge heavy atoms (i.e. heavy atoms bonded to neighbour residues)
-            and find the shortest chain between them: the backbone. Edge
-            atoms + backbone COM are used to determine UA translational axes
-            (see get_residue_custom_axes)
-            compute a custom MOI tensor using heavy-atom coordinates but UA masses
-            (heavy + bonded H masses), then compute the principal axes from it.
+            edge heavy atoms (i.e. heavy atoms bonded to neighbour residues).
+            If there are no bonds to neighbouring residues, use residue
+            .principal axes Otherwise, find the shortest chain between edge
+            residues: the backbone. Edge atoms + backbone COM are used to
+            determine UA translational axes (see get_residue_custom_axes)
 
         - Rotational axes:
             Identify heavy atoms in the residue/molecule of interest and choose
             the `index`-th heavy atom (where index corresponds to the bead index).
             Use bonded topology around that heavy atom to determine UA rotational
             axes (see :meth:`get_bonded_axes`).
+            Compute a custom MOI tensor using heavy-atom coordinates but UA masses
+            (heavy + bonded H masses), then compute the principal axes from it.
 
         Args:
             data_container (MDAnalysis.Universe or AtomGroup):
@@ -589,23 +581,25 @@ class AxesCalculator:
             lies on the E1-E2 vector
             rot_axes: (3,3) rotation axes of residue
         """
-        # x axis is O-E1
-        E1C_vector = center - edges[0].position
+        first_edge_centre_of_geometry_vector = center - edges[0].position
         # look for projection of E1-O onto E1-E2 (E1-C)
-        E1E2_vector = edges[1].position - edges[0].position
-        E1O_vector = (
-            np.dot(E1E2_vector, E1C_vector) / (np.linalg.norm(E1E2_vector) ** 2)
-        ) * E1E2_vector
-        x_axis = -E1O_vector
+        first_edge_second_edge_vector = edges[1].position - edges[0].position
+        first_edge_origin_vector = (
+            np.dot(first_edge_second_edge_vector, first_edge_centre_of_geometry_vector)
+            / (np.linalg.norm(first_edge_second_edge_vector) ** 2)
+        ) * first_edge_second_edge_vector
+        x_axis = -first_edge_origin_vector
         # O-C = O-E1 + E1-C
-        OC_vector = -E1O_vector + E1C_vector
-        y_axis = OC_vector
+        origin_centre_of_geometry_vector = (
+            -first_edge_origin_vector + first_edge_centre_of_geometry_vector
+        )
+        y_axis = origin_centre_of_geometry_vector
         z_axis = np.cross(x_axis, y_axis)
         x_axis /= np.linalg.norm(x_axis)
         y_axis /= np.linalg.norm(y_axis)
         z_axis /= np.linalg.norm(z_axis)
         rot_axes = np.array([x_axis, y_axis, z_axis])
-        rot_center = E1O_vector + edges[0].position
+        rot_center = first_edge_origin_vector + edges[0].position
         return rot_center, rot_axes
 
     def get_bonded_axes(self, system, atom, dimensions: np.ndarray):

--- a/CodeEntropy/levels/axes.py
+++ b/CodeEntropy/levels/axes.py
@@ -78,13 +78,12 @@ class AxesCalculator:
             * Set translational axes equal to rotational axes (as per the original
               code convention).
         - If bonded to other residues:
-            Translational axes are principal axes of data_container.
-            Find edge heavy atoms (i.e. heavy atoms bonded to neighbour residues)
-            and find the shortest chain between them: the backbone. Edge
-            atoms + backbone COM are used to determine residue rotational axes.
-            (see get_residue_custom_axes)
-        Compute a custom MOI, using heavy atom positions and heavy atom+ hydrogen
-        masses.
+            * Translational axes are principal axes of data_container.
+            * Find edge heavy atoms (i.e. heavy atoms bonded to neighbour residues)
+              and find the shortest chain between them: the backbone. Edge
+              atoms + backbone COM are used to determine residue rotational axes.
+              (see get_residue_custom_axes).Compute a custom MOI, using heavy atom
+              positions and heavy atom + hydrogen masses.
 
         Args:
             data_container (MDAnalysis.Universe or AtomGroup):

--- a/CodeEntropy/levels/axes.py
+++ b/CodeEntropy/levels/axes.py
@@ -162,15 +162,9 @@ class AxesCalculator:
                     last = None
                     # look for last heavy atom
                     # with only one bond to another
-                    while last_index > 0 and last is None:
+                    if last_index > 0 and last is None:
                         heavy_atom = uas[last_index]
-                        bonded_atoms = residue.atoms.select_atoms(
-                            f"(mass 2 to 999) and bonded index {heavy_atom.index}"
-                        )
-                        if len(bonded_atoms) == 1:
-                            last = heavy_atom
-                        else:
-                            last_index -= 1
+                        last = heavy_atom
                     edges = [edge_atom_set[0], last]
 
                     backbone = self.get_chain(residue, edge_atom_set[0], last)
@@ -352,15 +346,9 @@ class AxesCalculator:
                     last = None
                     # look for last heavy atom
                     # with only one bond to another
-                    while last_index > 0 and last is None:
+                    if last_index > 0 and last is None:
                         heavy_atom = heavy_atoms[last_index]
-                        bonded_atoms = residue.atoms.select_atoms(
-                            f"(mass 2 to 999) and bonded index {heavy_atom.index}"
-                        )
-                        if len(bonded_atoms) == 1:
-                            last = heavy_atom
-                        else:
-                            last_index -= 1
+                        last = heavy_atom
 
                     edges = [first_edge.atoms[0], last]
                     backbone = self.get_chain(residue, first_edge.atoms[0], last)

--- a/CodeEntropy/levels/axes.py
+++ b/CodeEntropy/levels/axes.py
@@ -61,13 +61,15 @@ class AxesCalculator:
         self._rot_axes = None
         self._number_of_beads = None
 
-    def get_residue_axes(self, data_container, index: int, residue=None):
+    def get_residue_axes(
+        self, data_container, index: int, relative_index: int, residue=None
+    ):
         """Compute residue-level translational and rotational axes.
 
         The translational and rotational axes at the residue level.
 
         - Identify the residue (either provided or selected by `resindex index`).
-        - Determine whether the residue is bonded to neighboring residues
+        - Determine whether the residue is bonded to neighbouring residues
           (previous/next in sequence) using MDAnalysis bonded selections.
         - If there are *no* bonds to other residues:
             * Use a custom principal axes, from a moment-of-inertia (MOI) tensor
@@ -76,13 +78,19 @@ class AxesCalculator:
             * Set translational axes equal to rotational axes (as per the original
               code convention).
         - If bonded to other residues:
-            * Use default axes and MOI (MDAnalysis principal axes / inertia).
+            Find edge heavy atoms (i.e. heavy atoms bonded to neighbour residues)
+            and find the shortest chain between them: the backbone. Edge
+            atoms + backbone COM are used to determine UA translational axes
+            (see get_residue_custom_axes)
 
         Args:
             data_container (MDAnalysis.Universe or AtomGroup):
                 Molecule and trajectory data (the fragment/molecule container).
             index (int):
                 Residue index (resindex) within `data_container`.
+            relative_index (int):
+                Index of first residue within 'data_container'.
+                This is used to obtain index in MDA Universe for atom selections.
             residue (MDAnalysis.AtomGroup, optional):
                 If provided, this residue selection will be used rather than
                 selecting again.
@@ -99,41 +107,93 @@ class AxesCalculator:
                 If the residue selection is empty.
         """
         # TODO refine selection so that it will work for branched polymers
-        index_prev = index - 1
-        index_next = index + 1
+        # match indexing to MDAnalysis indexing
+
+        index_prev = index + relative_index - 1
+        index_next = index + relative_index + 1
 
         if residue is None:
-            residue = data_container.select_atoms(f"resindex {index}")
+            residue = data_container.select_atoms(f"resindex {index + relative_index}")
+            # residue of interest
         if len(residue) == 0:
-            raise ValueError(f"Empty residue selection for resindex={index}")
+            raise ValueError(
+                f"Empty residue selection for resindex={index + relative_index}"
+            )
 
-        center = residue.atoms.center_of_mass(unwrap=True)
-        atom_set = data_container.select_atoms(
-            f"(resindex {index_prev} or resindex {index_next}) and bonded resid {index}"
+        edge_atom_set = data_container.atoms.select_atoms(
+            f"resindex {index + relative_index} and "
+            f"(bonded resindex {index_prev} or "
+            f"resindex {index_next})"
         )
 
-        if len(atom_set) == 0:
-            # No bonds to other residues.
+        uas = residue.select_atoms("mass 2 to 999")
+        ua_masses = self.get_UA_masses(residue)
+
+        if len(edge_atom_set) == 0:
+            # No UAS are bonded to other residues
             # Use a custom principal axes, from a MOI tensor that uses positions of
             # heavy atoms only, but including masses of heavy atom + bonded H.
-            uas = residue.select_atoms("mass 2 to 999")
-            ua_masses = self.get_UA_masses(residue)
+
             moi_tensor = self.get_moment_of_inertia_tensor(
-                center_of_mass=center,
+                center_of_mass=np.array(residue.center_of_mass()),
                 positions=uas.positions,
                 masses=ua_masses,
                 dimensions=data_container.dimensions[:3],
             )
             rot_axes, moment_of_inertia = self.get_custom_principal_axes(moi_tensor)
             trans_axes = rot_axes  # per original convention
+            rot_center = np.array(residue.center_of_mass())
         else:
-            # If bonded to other residues, use default axes and MOI.
+            # If bonded to other residues, use local axes.
             make_whole(data_container.atoms)
             trans_axes = data_container.atoms.principal_axes()
-            rot_axes, moment_of_inertia = self.get_vanilla_axes(residue)
-            center = residue.center_of_mass(unwrap=True)
 
-        return trans_axes, rot_axes, center, moment_of_inertia
+            if len(edge_atom_set) == 1:
+                if index == 0:
+                    # first residue
+                    # use first heavy atom
+                    edges = [residue.atoms[0], edge_atom_set[0]]
+                    backbone = self.get_chain(
+                        residue, residue.atoms[0], edge_atom_set[0]
+                    )
+                else:
+                    # last residue
+                    last_index = len(uas) - 1
+                    last = None
+                    # look for last heavy atom
+                    # with only one bond to another
+                    while last_index > 0 and last is None:
+                        heavy_atom = uas[last_index]
+                        bonded_atoms = residue.atoms.select_atoms(
+                            f"(mass 2 to 999) and bonded index {heavy_atom.index}"
+                        )
+                        if len(bonded_atoms) == 1:
+                            last = heavy_atom
+                        else:
+                            last_index -= 1
+                    edges = [edge_atom_set[0], last]
+
+                    backbone = self.get_chain(residue, edge_atom_set[0], last)
+            else:
+                # residue has two bonds to other residues
+                edges = [edge_atom_set[0], edge_atom_set[1]]
+                backbone = self.get_chain(residue, edge_atom_set[0], edge_atom_set[1])
+            # get edge atoms of the residue
+            # for terminal residues, this will include the C/N terminus
+            backbone_center = np.zeros(3)
+            for heavy_atom in backbone:
+                backbone_center += heavy_atom.position
+            backbone_center = backbone_center / len(backbone)
+            rot_center, rot_axes = self.get_residue_custom_axes(edges, backbone_center)
+
+            moment_of_inertia = self.get_custom_residue_moment_of_inertia(
+                center_of_mass=rot_center,
+                positions=uas.positions,
+                masses=ua_masses,
+                custom_rot_axes=rot_axes,
+                dimensions=data_container.dimensions[:3],
+            )
+        return trans_axes, rot_axes, rot_center, moment_of_inertia
 
     def get_residue_axes_from_topology(
         self,
@@ -193,7 +253,7 @@ class AxesCalculator:
 
         return trans_axes, rot_axes, center, moment_of_inertia
 
-    def get_UA_axes(self, data_container, index: int):
+    def get_UA_axes(self, data_container, index: int, res_position):
         """Compute united-atom-level translational and rotational axes.
 
         The translational and rotational axes at the united-atom level.
@@ -201,7 +261,12 @@ class AxesCalculator:
         This preserves the original behaviour and its rationale:
 
         - Translational axes:
-            Use the same custom principal-axes approach as residue level:
+            Use the same approach as residue level rotational.
+            Identify residue of interest and neighbours, then select
+            edge heavy atoms (i.e. heavy atoms bonded to neighbour residues)
+            and find the shortest chain between them: the backbone. Edge
+            atoms + backbone COM are used to determine UA translational axes
+            (see get_residue_custom_axes)
             compute a custom MOI tensor using heavy-atom coordinates but UA masses
             (heavy + bonded H masses), then compute the principal axes from it.
 
@@ -216,7 +281,8 @@ class AxesCalculator:
                 Molecule and trajectory data.
             index (int):
                 Bead index (ordinal among heavy atoms).
-
+            res_position: where the residue of interest is
+                in data_container
         Returns:
             Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
                 - trans_axes: Translational axes (3, 3).
@@ -228,51 +294,130 @@ class AxesCalculator:
             IndexError:
                 If `index` does not correspond to an existing heavy atom.
             ValueError:
-                If bonded-axis construction fails.
+                If axis construction fails.
         """
 
-        index = int(index)  # bead index
-
+        index = int(index)  # UA bead index
+        heavy_atoms = data_container.select_atoms("mass 2 to 999")
         # use the same customPI trans axes as the residue level
-        heavy_atoms = data_container.select_atoms("prop mass > 1.1")
         if len(heavy_atoms) > 1:
-            UA_masses = self.get_UA_masses(data_container.atoms)
-            center = data_container.atoms.center_of_mass(unwrap=True)
-            moment_of_inertia_tensor = self.get_moment_of_inertia_tensor(
-                center, heavy_atoms.positions, UA_masses, data_container.dimensions[:3]
+            if len(data_container.residues) == 1:
+                # only the one residue => use principal axes
+                residue = data_container
+                trans_center = data_container.atoms.center_of_mass(unwrap=True)
+                trans_axes = data_container.atoms.principal_axes()
+                residue_heavy_atoms = heavy_atoms
+            else:
+                # residue of interest has at least one neighbour
+                if res_position == -1:
+                    residue = data_container.residues[0]
+                    resindex = residue.resindex
+                    resindex_next = resindex + 1
+
+                    second_edge = data_container.select_atoms(
+                        f"resindex {resindex} and bonded resindex {resindex_next}"
+                    )
+
+                    edges = [residue.atoms[0], second_edge[0]]
+                    backbone = self.get_chain(
+                        residue, residue.atoms[0], second_edge.atoms[0]
+                    )
+
+                elif res_position == 0:
+                    # between 2 residues
+                    residue = data_container.residues[1]
+                    resindex = residue.resindex
+                    resindex_next = resindex + 1
+                    resindex_prev = resindex - 1
+
+                    edge_set = data_container.select_atoms(
+                        f"resindex {resindex} and "
+                        f"(bonded resindex {resindex_prev} or "
+                        f"resindex {resindex_next})"
+                    )
+
+                    edges = [edge_set[0], edge_set[1]]
+                    backbone = self.get_chain(residue, edge_set[0], edge_set[1])
+
+                else:
+                    # last resid
+                    # always resindex 1 in data_container
+                    residue = data_container.residues[1]
+                    resindex = residue.resindex
+                    resindex_prev = resindex - 1
+                    first_edge = data_container.select_atoms(
+                        f"resindex {resindex} and bonded resindex {resindex_prev}"
+                    )
+
+                    last_index = len(heavy_atoms) - 1
+                    last = None
+                    # look for last heavy atom
+                    # with only one bond to another
+                    while last_index > 0 and last is None:
+                        heavy_atom = heavy_atoms[last_index]
+                        bonded_atoms = residue.atoms.select_atoms(
+                            f"(mass 2 to 999) and bonded index {heavy_atom.index}"
+                        )
+                        if len(bonded_atoms) == 1:
+                            last = heavy_atom
+                        else:
+                            last_index -= 1
+
+                    edges = [first_edge.atoms[0], last]
+                    backbone = self.get_chain(residue, first_edge.atoms[0], last)
+
+                backbone_center = np.zeros(3)
+                for heavy_atom in backbone:
+                    backbone_center += heavy_atom.position
+                backbone_center = backbone_center / len(backbone)
+
+                trans_center, trans_axes = self.get_residue_custom_axes(
+                    edges, backbone_center
+                )
+                residue_heavy_atoms = residue.atoms.select_atoms("mass 2 to 999")
+
+            # look for heavy atoms in residue of interest
+            heavy_atom_indices = []
+            for atom in residue_heavy_atoms:
+                heavy_atom_indices.append(atom.index)
+            # we find the nth heavy atom
+            # where n is the bead index
+            heavy_atom_index = heavy_atom_indices[index]
+            heavy_atom = residue.atoms.select_atoms(f"index {heavy_atom_index}")[0]
+            rot_center = heavy_atom.position
+            rot_axes, moment_of_inertia = self.get_bonded_axes(
+                system=data_container,
+                atom=heavy_atom,
+                dimensions=data_container.dimensions[:3],
             )
-            trans_axes, _moment_of_inertia = self.get_custom_principal_axes(
-                moment_of_inertia_tensor
-            )
+
         else:
-            # use standard PA for UA not bonded to anything else
-            make_whole(data_container.atoms)
-            trans_axes = data_container.atoms.principal_axes()
+            # 1 heavy atom in the data_container
+            heavy_atom = heavy_atoms[0]
+            # trans and rot centres are centre of mass
+            rot_center = data_container.center_of_mass()
+            rot_axes, moment_of_inertia = self.get_bonded_axes(
+                system=data_container,
+                atom=heavy_atom,
+                dimensions=data_container.dimensions[:3],
+            )
+            trans_center = rot_center
+            # principal axes
+            trans_axes = rot_axes
 
-        # look for heavy atoms in residue of interest
-        heavy_atom_indices = []
-        for atom in heavy_atoms:
-            heavy_atom_indices.append(atom.index)
-        # we find the nth heavy atom
-        # where n is the bead index
-        heavy_atom_index = heavy_atom_indices[index]
-        heavy_atom = data_container.select_atoms(f"index {heavy_atom_index}")
+        if trans_axes is None:
+            raise ValueError("Unable to compute translation axes for UA bead.")
 
-        center = heavy_atom.positions[0]
-        rot_axes, moment_of_inertia = self.get_bonded_axes(
-            system=data_container,
-            atom=heavy_atom[0],
-            dimensions=data_container.dimensions[:3],
-        )
         if rot_axes is None or moment_of_inertia is None:
             raise ValueError("Unable to compute bonded axes for UA bead.")
 
-        logger.debug(f"Translational Axes: {trans_axes}")
-        logger.debug(f"Rotational Axes: {rot_axes}")
-        logger.debug(f"Center: {center}")
-        logger.debug(f"Moment of Inertia: {moment_of_inertia}")
+        logger.debug("Translational Axes: %s", trans_axes)
+        logger.debug("Rotational Axes: %s", rot_axes)
+        logger.debug("Translational center: %s", trans_center)
+        logger.debug("Rotational center: %s", rot_center)
+        logger.debug("Moment of Inertia: %s", moment_of_inertia)
 
-        return trans_axes, rot_axes, center, moment_of_inertia
+        return trans_axes, rot_axes, rot_center, moment_of_inertia
 
     def get_UA_axes_from_topology(
         self,
@@ -659,6 +804,41 @@ class AxesCalculator:
         scaled_custom_axes = unscaled_custom_axes / mod[:, np.newaxis]
         return scaled_custom_axes
 
+    def get_custom_residue_moment_of_inertia(
+        self,
+        center_of_mass: np.ndarray,
+        positions: np.ndarray,
+        masses: np.ndarray,
+        custom_rot_axes: np.ndarray,
+        dimensions: np.ndarray,
+    ):
+        """
+        Compute moment of inertia around custom axes for a bead
+        formed of multiple UAs.
+
+        Args:
+            center_of_mass: (3, ) COM for bead
+            positions: (N,3) positions of the UAs in the bead
+            masses: (N,) masses of the UAs in the bead
+            custom_rot_axes: (3,3) array of residue rotation axes
+            dimensions: (3,) simulation_box_dimensions
+
+        Returns:
+            np.ndarray: (3,) moment of inertia array.
+
+        """
+
+        translated_coords = self.get_vector(center_of_mass, positions, dimensions)
+        custom_moment_of_inertia = np.zeros(3, dtype=float)
+
+        for coord, mass in zip(translated_coords, masses, strict=True):
+            axis_component = np.sum(
+                np.cross(custom_rot_axes, coord) ** 2 * mass, axis=1
+            )
+            custom_moment_of_inertia += axis_component
+
+        return custom_moment_of_inertia
+
     def get_custom_moment_of_inertia(
         self,
         UA,
@@ -849,3 +1029,78 @@ class AxesCalculator:
                     ua_mass += float(h.mass)
                 ua_masses.append(ua_mass)
         return ua_masses
+
+    def get_chain(self, residue, first, last):
+        """
+        For a given MDAnalysis AtomGroup and two given heavy atoms
+        within that AtomGroup, return the
+        shortest path between the two atoms.
+
+        Args:
+            residue: MDAnalysis AtomGroup representing
+            the residue/monomer of interest.
+            first: First heavy atom in the chain
+            last: Last heavy atom in the chain
+
+        Returns:
+            chain: Array containing chain atoms.
+        """
+
+        chain = []
+        # at the beggining we've only visited the first atom
+        visited_dict = {first: True}
+        # keep the previous atom to trace back the path
+        prev = {}
+        # queue of next heavy atoms to visit
+        next_to_visit = [first]
+        # all others heavy atoms in the residue, we have not yet visited
+        remaining_heavy_atoms = residue.atoms.select_atoms(
+            f"(mass 2 to 999) and not index {first.index}"
+        )
+        for atom in remaining_heavy_atoms:
+            visited_dict[atom] = False
+        current = first
+
+        while not visited_dict[last]:
+            # we haven't found a path to the last residue
+            next_to_visit.pop(0)
+            # we're visiting the current atom => we remove it from the queue
+            bonded_atoms = residue.atoms.select_atoms(
+                f"(mass 2 to 999) and bonded index {current.index}"
+            )
+
+            if last in bonded_atoms:
+                # we found a path to the last atom
+                visited_dict[last] = True
+                chain.append(last)
+                prev[last] = current
+
+            else:
+                for bonded_atom in bonded_atoms:
+                    # look for unvisited bonded atoms to the current atom we're visiting
+                    if not visited_dict[bonded_atom]:
+                        # we're going to want to visit the atoms
+                        next_to_visit.append(bonded_atom)
+                        prev[bonded_atom] = current
+                # we visit the next atom in the queue
+                current = next_to_visit[0]
+                visited_dict[current] = True
+
+        # we track the previous atom back to the first atom now
+        current = last
+        chain = [last]
+        # subtract index of first atom in resid
+        # most likely will coincide with first
+        # but this will work even if it doesn't
+        # accout for in-residue index
+        # start from last atom in chain
+        while chain[-1] != first:
+            # we haven't yet returned to the first atom
+            current = prev[current]
+            chain.append(current)
+
+        chain = np.flip(chain)
+        # only get in between residues
+        chain = chain[1:-1]
+        # accout for in-residue index
+        return chain

--- a/CodeEntropy/levels/nodes/covariance.py
+++ b/CodeEntropy/levels/nodes/covariance.py
@@ -480,6 +480,7 @@ class FrameCovarianceNode:
                     )
 
                 if ua_topology is not None:
+                    print("This is where we should be")
                     trans_axes, rot_axes, center, moi = (
                         axes_manager.get_UA_axes_from_topology(
                             u=u,
@@ -489,22 +490,21 @@ class FrameCovarianceNode:
                         )
                     )
                 else:
-                    trans_axes, rot_axes, center, moi = axes_manager.get_UA_axes(
-                        residue_group, ua_i, res_position
-                    )
+                    make_whole(residue_group)
+                    make_whole(bead)
+                    if res_position == -1:
+                        # first residue in group
+                        residue = residue_group.residues[0]
+                    elif res_position == 0 or res_position == 1:
+                        # middle or last residue => second in group
+                        residue = residue_group.residues[1]
+                    else:
+                        # res_position is None bc there is only one residue
+                        residue = residue_group
+                        trans_axes, rot_axes, center, moi = axes_manager.get_UA_axes(
+                            residue_group, ua_i, res_position
+                        )
             else:
-                make_whole(residue_group)
-                make_whole(bead)
-                if res_position == -1:
-                    # first residue in group
-                    residue = residue_group.residues[0]
-                elif res_position == 0 or res_position == 1:
-                    # middle or last residue => second in group
-                    residue = residue_group.residues[1]
-                else:
-                    # res_position is None bc there is only one residue
-                    residue = residue_group
-
                 trans_axes = residue.principal_axes()
                 rot_axes, moi = axes_manager.get_vanilla_axes(bead)
                 center = bead.center_of_mass(unwrap=True)

--- a/CodeEntropy/levels/nodes/covariance.py
+++ b/CodeEntropy/levels/nodes/covariance.py
@@ -472,40 +472,40 @@ class FrameCovarianceNode:
         torque_vecs: list[np.ndarray] = []
 
         for ua_i, bead in enumerate(bead_groups):
+            if res_position == -1:
+                # first residue in group
+                residue = residue_group.residues[0]
+            elif res_position == 0 or res_position == 1:
+                # middle or last residue => second in group
+                residue = residue_group.residues[1]
+            else:
+                # res_position is None bc there is only one residue
+                residue = residue_group
+
             if customised_axes:
                 ua_topology = None
                 if axes_topology is not None:
-                    ua_topology = axes_topology.ua.get(
-                        (mol_id, local_res_i, ua_i, res_position)
-                    )
-
+                    ua_topology = axes_topology.ua.get((mol_id, local_res_i, ua_i))
                 if ua_topology is not None:
-                    print("This is where we should be")
                     trans_axes, rot_axes, center, moi = (
                         axes_manager.get_UA_axes_from_topology(
                             u=u,
-                            residue_group=residue_group,
+                            residue_atoms=residue.atoms,
                             topology=ua_topology,
                             box=box,
                         )
                     )
                 else:
+                    # we don't use the topology
                     make_whole(residue_group)
                     make_whole(bead)
-                    if res_position == -1:
-                        # first residue in group
-                        residue = residue_group.residues[0]
-                    elif res_position == 0 or res_position == 1:
-                        # middle or last residue => second in group
-                        residue = residue_group.residues[1]
-                    else:
-                        # res_position is None bc there is only one residue
-                        residue = residue_group
-                        trans_axes, rot_axes, center, moi = axes_manager.get_UA_axes(
-                            residue_group, ua_i, res_position
-                        )
+                    trans_axes, rot_axes, center, moi = axes_manager.get_UA_axes(
+                        residue_group, ua_i, res_position
+                    )
+
             else:
-                trans_axes = residue.principal_axes()
+                # principal axes
+                trans_axes = residue.atoms.principal_axes()
                 rot_axes, moi = axes_manager.get_vanilla_axes(bead)
                 center = bead.center_of_mass(unwrap=True)
 

--- a/CodeEntropy/levels/nodes/covariance.py
+++ b/CodeEntropy/levels/nodes/covariance.py
@@ -565,6 +565,8 @@ class FrameCovarianceNode:
         force_vecs: list[np.ndarray] = []
         torque_vecs: list[np.ndarray] = []
 
+        relative_res_i = mol.residues[0].resindex
+
         for local_res_i, bead in enumerate(bead_groups):
             trans_axes, rot_axes, center, moi = self._get_residue_axes(
                 u=u,
@@ -572,6 +574,7 @@ class FrameCovarianceNode:
                 mol_id=mol_id,
                 bead=bead,
                 local_res_i=local_res_i,
+                relative_res_i=relative_res_i,
                 axes_manager=axes_manager,
                 axes_topology=axes_topology,
                 box=box,
@@ -608,6 +611,7 @@ class FrameCovarianceNode:
         mol_id: int,
         bead: Any,
         local_res_i: int,
+        relative_res_i: int,
         axes_manager: Any,
         axes_topology: Any | None,
         box: np.ndarray | None,
@@ -621,6 +625,8 @@ class FrameCovarianceNode:
             mol_id: Molecule index used in axes-topology lookup keys.
             bead: Atom group representing the residue bead.
             local_res_i: Residue index local to ``mol``.
+            relative_res_i: Residue index of first residue within ``mol``. This
+            might differ from residue index of first residue in topology.
             axes_manager: Axes helper used to select axes, centres, and moments.
             axes_topology: Optional cached axes topology generated during static setup.
             box: Optional periodic box vector.
@@ -644,7 +650,9 @@ class FrameCovarianceNode:
                     box=box,
                 )
 
-            return axes_manager.get_residue_axes(mol, local_res_i, residue=res.atoms)
+            return axes_manager.get_residue_axes(
+                mol, local_res_i, relative_res_i, residue=res.atoms
+            )
 
         make_whole(mol.atoms)
         make_whole(bead)

--- a/CodeEntropy/levels/nodes/covariance.py
+++ b/CodeEntropy/levels/nodes/covariance.py
@@ -203,6 +203,39 @@ class FrameCovarianceNode:
             molcount: Per-residue group sample counters, mutated in place.
         """
         for local_res_i, res in enumerate(mol.residues):
+            if len(mol.residues) > 1:
+                # there are multiple residues in the molecule
+                # build residue group here
+                if local_res_i == 0:
+                    # first residue
+                    relative_id = res.resindex
+                    # index relative to first in mda universe
+                    res_position = -1
+                    residue_group = mol.select_atoms(
+                        f"resindex {local_res_i + relative_id} "
+                        f"or resindex {local_res_i + 1 + relative_id}"
+                    ).residues
+
+                elif local_res_i == len(mol.residues) - 1:
+                    # last residue
+                    res_position = 1
+                    residue_group = mol.select_atoms(
+                        f"resindex {local_res_i - 1 + relative_id} "
+                        f"or resindex {local_res_i + relative_id}"
+                    ).residues
+
+                else:
+                    res_position = 0
+                    residue_group = mol.select_atoms(
+                        f"resindex {local_res_i - 1 + relative_id} "
+                        f"or resindex {local_res_i + relative_id} "
+                        f"or resindex {local_res_i + 1 + relative_id}"
+                    ).residues
+
+            else:
+                # only one residue
+                res_position = None
+                residue_group = res
             bead_key = (mol_id, "united_atom", local_res_i)
             bead_idx_list = beads.get(bead_key, [])
             if not bead_idx_list:
@@ -216,7 +249,7 @@ class FrameCovarianceNode:
                 u=u,
                 mol_id=mol_id,
                 local_res_i=local_res_i,
-                residue_atoms=res.atoms,
+                residue_group=residue_group.atoms,
                 bead_groups=bead_groups,
                 axes_manager=axes_manager,
                 axes_topology=axes_topology,
@@ -224,6 +257,7 @@ class FrameCovarianceNode:
                 force_partitioning=force_partitioning,
                 customised_axes=customised_axes,
                 is_highest=is_highest,
+                res_position=res_position,
             )
 
             F, T = self._ft.compute_frame_covariance(force_vecs, torque_vecs)
@@ -406,13 +440,14 @@ class FrameCovarianceNode:
         mol_id: int,
         local_res_i: int,
         bead_groups: list[Any],
-        residue_atoms: Any,
+        residue_group: Any,
         axes_manager: Any,
         axes_topology: Any | None,
         box: np.ndarray | None,
         force_partitioning: float,
         customised_axes: bool,
         is_highest: bool,
+        res_position: int,
     ) -> tuple[list[np.ndarray], list[np.ndarray]]:
         """Build force and torque vectors for united-atom beads.
 
@@ -421,13 +456,14 @@ class FrameCovarianceNode:
             mol_id: Molecule index used in axes-topology lookup keys.
             local_res_i: Local residue index used in axes-topology lookup keys.
             bead_groups: Atom groups representing UA beads in a residue.
-            residue_atoms: Atom group for the parent residue.
+            residue_group: Atom group for the parent residue group.
             axes_manager: Axes helper used to select axes, centres, and moments.
             axes_topology: Optional cached axes topology generated during static setup.
             box: Optional periodic box vector.
             force_partitioning: Force partitioning factor for highest-level vectors.
             customised_axes: Whether customised UA axes should be used.
             is_highest: Whether UA is the highest active level.
+            res_position: Where the residue is in the residue group
 
         Returns:
             A tuple containing lists of force vectors and torque vectors.
@@ -439,26 +475,37 @@ class FrameCovarianceNode:
             if customised_axes:
                 ua_topology = None
                 if axes_topology is not None:
-                    ua_topology = axes_topology.ua.get((mol_id, local_res_i, ua_i))
+                    ua_topology = axes_topology.ua.get(
+                        (mol_id, local_res_i, ua_i, res_position)
+                    )
 
                 if ua_topology is not None:
                     trans_axes, rot_axes, center, moi = (
                         axes_manager.get_UA_axes_from_topology(
                             u=u,
-                            residue_atoms=residue_atoms,
+                            residue_group=residue_group,
                             topology=ua_topology,
                             box=box,
                         )
                     )
                 else:
                     trans_axes, rot_axes, center, moi = axes_manager.get_UA_axes(
-                        residue_atoms, ua_i
+                        residue_group, ua_i, res_position
                     )
             else:
-                make_whole(residue_atoms)
+                make_whole(residue_group)
                 make_whole(bead)
+                if res_position == -1:
+                    # first residue in group
+                    residue = residue_group.residues[0]
+                elif res_position == 0 or res_position == 1:
+                    # middle or last residue => second in group
+                    residue = residue_group.residues[1]
+                else:
+                    # res_position is None bc there is only one residue
+                    residue = residue_group
 
-                trans_axes = residue_atoms.principal_axes()
+                trans_axes = residue.principal_axes()
                 rot_axes, moi = axes_manager.get_vanilla_axes(bead)
                 center = bead.center_of_mass(unwrap=True)
 

--- a/CodeEntropy/levels/nodes/covariance.py
+++ b/CodeEntropy/levels/nodes/covariance.py
@@ -185,6 +185,15 @@ class FrameCovarianceNode:
         molcount: dict[tuple[int, int], int],
     ) -> None:
         """Compute united-atom second moments for one molecule.
+        If there are multiple residues in the molecule, build
+        residue group and attribute res_position:
+            - First residue: residue_group contains first two
+            residues. res_position is -1.
+            - Last residue: residue_group contains last two
+            residues. res_position is 1.
+            - Non-terminal residue: residue_group contains
+            residue of interest + two neighbours. res_position
+            is 0.
 
         Args:
             u: Universe-like object used to resolve bead atom indices.
@@ -204,10 +213,7 @@ class FrameCovarianceNode:
         """
         for local_res_i, res in enumerate(mol.residues):
             if len(mol.residues) > 1:
-                # there are multiple residues in the molecule
-                # build residue group here
                 if local_res_i == 0:
-                    # first residue
                     relative_id = res.resindex
                     # index relative to first in mda universe
                     res_position = -1
@@ -216,7 +222,6 @@ class FrameCovarianceNode:
                         f"or resindex {local_res_i + 1 + relative_id}"
                     )
                 elif local_res_i == len(mol.residues) - 1:
-                    # last residue
                     res_position = 1
                     residue_group = mol.select_atoms(
                         f"resindex {local_res_i - 1 + relative_id} "
@@ -231,7 +236,6 @@ class FrameCovarianceNode:
                     )
 
             else:
-                # only one residue
                 res_position = None
                 residue_group = res
             bead_key = (mol_id, "united_atom", local_res_i)
@@ -471,13 +475,10 @@ class FrameCovarianceNode:
 
         for ua_i, bead in enumerate(bead_groups):
             if res_position == -1:
-                # first residue in group
                 residue = residue_group.residues[0]
             elif res_position == 0 or res_position == 1:
-                # middle or last residue => second in group
                 residue = residue_group.residues[1]
             else:
-                # res_position is None bc there is only one residue
                 residue = residue_group
 
             if customised_axes:

--- a/CodeEntropy/levels/nodes/covariance.py
+++ b/CodeEntropy/levels/nodes/covariance.py
@@ -505,6 +505,8 @@ class FrameCovarianceNode:
 
             else:
                 # principal axes
+                make_whole(residue.atoms)
+                make_whole(bead)
                 trans_axes = residue.atoms.principal_axes()
                 rot_axes, moi = axes_manager.get_vanilla_axes(bead)
                 center = bead.center_of_mass(unwrap=True)

--- a/CodeEntropy/levels/nodes/covariance.py
+++ b/CodeEntropy/levels/nodes/covariance.py
@@ -214,23 +214,21 @@ class FrameCovarianceNode:
                     residue_group = mol.select_atoms(
                         f"resindex {local_res_i + relative_id} "
                         f"or resindex {local_res_i + 1 + relative_id}"
-                    ).residues
-
+                    )
                 elif local_res_i == len(mol.residues) - 1:
                     # last residue
                     res_position = 1
                     residue_group = mol.select_atoms(
                         f"resindex {local_res_i - 1 + relative_id} "
                         f"or resindex {local_res_i + relative_id}"
-                    ).residues
-
+                    )
                 else:
                     res_position = 0
                     residue_group = mol.select_atoms(
                         f"resindex {local_res_i - 1 + relative_id} "
                         f"or resindex {local_res_i + relative_id} "
                         f"or resindex {local_res_i + 1 + relative_id}"
-                    ).residues
+                    )
 
             else:
                 # only one residue
@@ -249,7 +247,7 @@ class FrameCovarianceNode:
                 u=u,
                 mol_id=mol_id,
                 local_res_i=local_res_i,
-                residue_group=residue_group.atoms,
+                residue_group=residue_group,
                 bead_groups=bead_groups,
                 axes_manager=axes_manager,
                 axes_topology=axes_topology,

--- a/docs/science.rst
+++ b/docs/science.rst
@@ -72,9 +72,9 @@ For the polymer level, the translational and rotational axes are defined as the 
 
 For the residue level, there are two situations.
 When the residue is not bonded to any other residues, the translational and rotational axes are the principal axes of the molecule.
-When the residue is part of a larger polymer, the translational axes are the principal axes of the polymer, and the rotational axes are defined from the average position of the bonds to neighbouring residues.
+When the residue is part of a larger polymer, the translational axes are the principal axes of the polymer, and the rotational axes are defined from the two heavy atoms bonded to neighbour residues(E1,E2) and the average position of all other backbone atoms in the residue (C). The backbone of a residue is defined as the shortest path between the two edge atoms of the residue, i.e. the two heavy atoms bonded to neighbour residues.The centre of rotation is located at the point where the perpendicular from C meets the E1-E2 vector.
 
-For the united atom level, the translational axes are defined as the principal axes of the residue and the rotational axes are defined from the average position of the bonds to neighbouring heavy atoms.
+For the united atom level, the translational axes are defined as the residue rotational axes and the rotational axes are defined from the average position of the bonds to neighbouring heavy atoms.
 If there are no bonds to other heavy atoms, the principal axes of the molecule are used.
 
 Conformational Entropy

--- a/tests/unit/CodeEntropy/levels/nodes/test_covariance_node.py
+++ b/tests/unit/CodeEntropy/levels/nodes/test_covariance_node.py
@@ -428,13 +428,14 @@ def test_build_ua_vectors_uses_customised_axes():
         mol_id=0,
         local_res_i=0,
         bead_groups=[FakeAtomGroup("ua")],
-        residue_atoms=FakeAtomGroup("res"),
+        residue_group=FakeAtomGroup("res"),
         axes_manager=axes_manager,
         axes_topology=None,
         box=None,
         force_partitioning=0.5,
         customised_axes=True,
         is_highest=True,
+        res_position=None,
     )
 
     assert len(force_vecs) == 1
@@ -464,13 +465,14 @@ def test_build_ua_vectors_uses_cached_axes_topology_when_available():
         mol_id=3,
         local_res_i=4,
         bead_groups=[FakeAtomGroup("ua")],
-        residue_atoms=FakeAtomGroup("res"),
+        residue_group=FakeAtomGroup("res"),
         axes_manager=axes_manager,
         axes_topology=axes_topology,
         box=None,
         force_partitioning=0.5,
         customised_axes=True,
         is_highest=True,
+        res_position=None,
     )
 
     assert len(force_vecs) == 1
@@ -501,13 +503,14 @@ def test_build_ua_vectors_uses_vanilla_axes_when_not_customised():
             mol_id=0,
             local_res_i=0,
             bead_groups=[FakeAtomGroup("ua")],
-            residue_atoms=FakeAtomGroup("res"),
+            residue_group=FakeAtomGroup("res"),
             axes_manager=axes_manager,
             axes_topology=None,
             box=None,
             force_partitioning=0.5,
             customised_axes=False,
             is_highest=False,
+            res_position=None,
         )
 
     assert make_whole.call_count == 2
@@ -558,6 +561,7 @@ def test_get_residue_axes_customised_uses_cached_topology_when_available():
         mol_id=3,
         bead=FakeAtomGroup("res"),
         local_res_i=0,
+        relative_res_i=0,
         axes_manager=axes_manager,
         axes_topology=axes_topology,
         box=None,
@@ -585,6 +589,7 @@ def test_get_residue_axes_customised_delegates_to_axes_manager():
             mol_id=0,
             bead=FakeAtomGroup("res"),
             local_res_i=0,
+            relative_res_i=0,
             axes_manager=axes_manager,
             axes_topology=None,
             box=None,

--- a/tests/unit/CodeEntropy/levels/nodes/test_covariance_node.py
+++ b/tests/unit/CodeEntropy/levels/nodes/test_covariance_node.py
@@ -759,3 +759,67 @@ def test_process_united_atom_multiple_residues(monkeypatch):
         molcount=molcount,
     )
     assert mol.select_atoms.call_count == 3
+
+
+def test_build_ua_vectors_multiple_residues_first_residue():
+    node = FrameCovarianceNode()
+    axes_manager = MagicMock()
+    axes_manager.get_UA_axes.return_value = (
+        np.eye(3),
+        2.0 * np.eye(3),
+        np.ones(3),
+        np.array([1.0, 2.0, 3.0]),
+    )
+    node._ft.get_weighted_forces = MagicMock(return_value=np.array([1.0, 0.0, 0.0]))
+    node._ft.get_weighted_torques = MagicMock(return_value=np.array([0.0, 1.0, 0.0]))
+
+    with patch("CodeEntropy.levels.nodes.covariance.make_whole") as make_whole:
+        force_vecs, torque_vecs = node._build_ua_vectors(
+            u=FakeUniverse([]),
+            mol_id=0,
+            local_res_i=0,
+            bead_groups=[FakeAtomGroup("ua")],
+            residue_group=FakeMolecule(n_residues=2),
+            axes_manager=axes_manager,
+            axes_topology=None,
+            box=None,
+            force_partitioning=0.5,
+            customised_axes=True,
+            is_highest=True,
+            res_position=-1,
+        )
+
+    assert make_whole.call_count == 2
+    axes_manager.get_UA_axes.assert_called_once()
+
+
+def test_build_ua_vectors_multiple_residues_middle_residue():
+    node = FrameCovarianceNode()
+    axes_manager = MagicMock()
+    axes_manager.get_UA_axes.return_value = (
+        np.eye(3),
+        2.0 * np.eye(3),
+        np.ones(3),
+        np.array([1.0, 2.0, 3.0]),
+    )
+    node._ft.get_weighted_forces = MagicMock(return_value=np.array([1.0, 0.0, 0.0]))
+    node._ft.get_weighted_torques = MagicMock(return_value=np.array([0.0, 1.0, 0.0]))
+
+    with patch("CodeEntropy.levels.nodes.covariance.make_whole") as make_whole:
+        force_vecs, torque_vecs = node._build_ua_vectors(
+            u=FakeUniverse([]),
+            mol_id=0,
+            local_res_i=0,
+            bead_groups=[FakeAtomGroup("ua")],
+            residue_group=FakeMolecule(n_residues=3),
+            axes_manager=axes_manager,
+            axes_topology=None,
+            box=None,
+            force_partitioning=0.5,
+            customised_axes=True,
+            is_highest=True,
+            res_position=0,
+        )
+
+    assert make_whole.call_count == 2
+    axes_manager.get_UA_axes.assert_called_once()

--- a/tests/unit/CodeEntropy/levels/nodes/test_covariance_node.py
+++ b/tests/unit/CodeEntropy/levels/nodes/test_covariance_node.py
@@ -16,6 +16,7 @@ class FakeAtomGroup:
         self.name = name
         self._length = length
         self.indices = np.arange(length)
+        self.atoms = self
 
     def __len__(self):
         return self._length
@@ -423,21 +424,23 @@ def test_build_ua_vectors_uses_customised_axes():
     node._ft.get_weighted_forces = MagicMock(return_value=np.array([1.0, 0.0, 0.0]))
     node._ft.get_weighted_torques = MagicMock(return_value=np.array([0.0, 1.0, 0.0]))
 
-    force_vecs, torque_vecs = node._build_ua_vectors(
-        u=FakeUniverse([]),
-        mol_id=0,
-        local_res_i=0,
-        bead_groups=[FakeAtomGroup("ua")],
-        residue_group=FakeAtomGroup("res"),
-        axes_manager=axes_manager,
-        axes_topology=None,
-        box=None,
-        force_partitioning=0.5,
-        customised_axes=True,
-        is_highest=True,
-        res_position=None,
-    )
+    with patch("CodeEntropy.levels.nodes.covariance.make_whole") as make_whole:
+        force_vecs, torque_vecs = node._build_ua_vectors(
+            u=FakeUniverse([]),
+            mol_id=0,
+            local_res_i=0,
+            bead_groups=[FakeAtomGroup("ua")],
+            residue_group=FakeAtomGroup("res"),
+            axes_manager=axes_manager,
+            axes_topology=None,
+            box=None,
+            force_partitioning=0.5,
+            customised_axes=True,
+            is_highest=True,
+            res_position=None,
+        )
 
+    assert make_whole.call_count == 2
     assert len(force_vecs) == 1
     assert len(torque_vecs) == 1
     axes_manager.get_UA_axes.assert_called_once()
@@ -446,7 +449,6 @@ def test_build_ua_vectors_uses_customised_axes():
 def test_build_ua_vectors_uses_cached_axes_topology_when_available():
     node = FrameCovarianceNode()
     axes_manager = MagicMock()
-
     u = FakeUniverse([])
     ua_topology = object()
     axes_topology = SimpleNamespace(ua={(3, 4, 0): ua_topology})
@@ -521,7 +523,8 @@ def test_build_residue_vectors_uses_residue_axes():
     node = FrameCovarianceNode()
     mol = FakeMolecule(n_residues=1)
     axes_manager = MagicMock()
-
+    residue = mol.residues[0]
+    residue.resindex = 0
     node._get_residue_axes = MagicMock(
         return_value=(np.eye(3), np.eye(3), np.zeros(3), np.ones(3))
     )
@@ -601,6 +604,7 @@ def test_get_residue_axes_customised_delegates_to_axes_manager():
     axes_manager.get_residue_axes.assert_called_once_with(
         mol,
         0,
+        0,
         residue=mol.residues[0].atoms,
     )
 
@@ -622,6 +626,7 @@ def test_get_residue_axes_vanilla_uses_make_whole_and_vanilla_axes():
             mol_id=0,
             bead=bead,
             local_res_i=0,
+            relative_res_i=0,
             axes_manager=axes_manager,
             axes_topology=None,
             box=None,

--- a/tests/unit/CodeEntropy/levels/nodes/test_covariance_node.py
+++ b/tests/unit/CodeEntropy/levels/nodes/test_covariance_node.py
@@ -33,16 +33,17 @@ class FakeResidue:
 
     def __init__(self, atoms=None):
         self.atoms = atoms or FakeAtomGroup("residue-atoms")
+        self.residues = self
 
 
 class FakeMolecule:
     """Small molecule-like fragment."""
 
-    def __init__(self, n_residues=1):
+    def __init__(self, n_residues, select_map=None):
         self.atoms = FakeAtomGroup("mol-atoms")
         self.residues = [FakeResidue() for _ in range(n_residues)]
+        self._select_map = dict(select_map or {})
 
-    @property
     def select_atoms(self, query: str):
         return self._select_map.get(query, FakeMolecule([]))
 
@@ -88,7 +89,7 @@ def test_run_processes_all_levels_and_writes_frame_covariance():
     node._process_residue = MagicMock()
     node._process_polymer = MagicMock()
 
-    mol = FakeMolecule()
+    mol = FakeMolecule(n_residues=1)
     universe = FakeUniverse([mol], dimensions=np.array([10.0, 20.0, 30.0, 90.0]))
     axes_manager = object()
     axes_topology = object()
@@ -137,7 +138,7 @@ def test_run_omits_forcetorque_when_combined_is_false():
 
     ctx = {
         "shared": {
-            "reduced_universe": FakeUniverse([FakeMolecule()]),
+            "reduced_universe": FakeUniverse([FakeMolecule(n_residues=1)]),
             "groups": {0: [0]},
             "levels": [["residue"]],
             "beads": {},
@@ -714,7 +715,7 @@ def test_build_ft_block_rejects_invalid_inputs():
         FrameCovarianceNode._build_ft_block([np.ones(2)], [np.ones(3)])
 
 
-def test_process_united_atom_multiple_residues():
+def test_process_united_atom_multiple_residues(monkeypatch):
     node = FrameCovarianceNode()
     mol = FakeMolecule(n_residues=3)
     bead_group = FakeAtomGroup("ua", length=3)
@@ -725,17 +726,14 @@ def test_process_united_atom_multiple_residues():
 
     def _select_atoms(q):
         if q == "resindex 0 or resindex 1":
-            return mol[0:2]
+            return FakeMolecule(n_residues=2)
         if q == "resindex 1 or resindex 2":
-            return mol[1:3]
+            return FakeMolecule(n_residues=2)
         if q == "resindex 0 or resindex 1 or resindex 2":
             return mol
 
-    mol.select_atoms.side_effect = _select_atoms
-
-    node._build_ua_vectors = MagicMock(
-        return_value=([np.array([1.0, 0.0, 0.0])], [np.array([0.0, 1.0, 0.0])])
-    )
+    mol.select_atoms = MagicMock(side_effect=_select_atoms)
+    node._build_ua_vectors = MagicMock(return_value=(np.eye(3), np.eye(3)))
     node._ft.compute_frame_covariance = MagicMock(
         return_value=(np.eye(3), 2.0 * np.eye(3))
     )
@@ -749,11 +747,7 @@ def test_process_united_atom_multiple_residues():
         mol=mol,
         mol_id=0,
         group_id=7,
-        beads={
-            (0, "united_atom", 0): [np.array([0])],
-            (0, "united_atom", 1): [np.array([1])],
-            (0, "united_atom", 2): [np.array([2])],
-        },
+        beads={(0, "united_atom", 0): [np.array([0])]},
         axes_manager="axes",
         axes_topology=None,
         box=None,
@@ -764,8 +758,4 @@ def test_process_united_atom_multiple_residues():
         out_torque=out_torque,
         molcount=molcount,
     )
-
-    np.testing.assert_allclose(out_force["ua"][(7, 0), (7, 1), (7, 2)], np.eye(3))
-    np.testing.assert_allclose(
-        out_torque["ua"][(7, 0), (7, 1), (7, 2)], 2.0 * np.eye(3)
-    )
+    assert mol.select_atoms.call_count == 3

--- a/tests/unit/CodeEntropy/levels/nodes/test_covariance_node.py
+++ b/tests/unit/CodeEntropy/levels/nodes/test_covariance_node.py
@@ -42,6 +42,10 @@ class FakeMolecule:
         self.atoms = FakeAtomGroup("mol-atoms")
         self.residues = [FakeResidue() for _ in range(n_residues)]
 
+    @property
+    def select_atoms(self, query: str):
+        return self._select_map.get(query, FakeMolecule([]))
+
 
 class FakeAtoms:
     """Container supporting u.atoms.fragments and u.atoms[index_array]."""
@@ -708,3 +712,60 @@ def test_build_ft_block_rejects_invalid_inputs():
 
     with pytest.raises(ValueError, match="length 3"):
         FrameCovarianceNode._build_ft_block([np.ones(2)], [np.ones(3)])
+
+
+def test_process_united_atom_multiple_residues():
+    node = FrameCovarianceNode()
+    mol = FakeMolecule(n_residues=3)
+    bead_group = FakeAtomGroup("ua", length=3)
+    universe = FakeUniverse([mol], returned_groups=[bead_group])
+    mol.residues[0].resindex = 0
+    mol.residues[1].resindex = 1
+    mol.residues[2].resindex = 2
+
+    def _select_atoms(q):
+        if q == "resindex 0 or resindex 1":
+            return mol[0:2]
+        if q == "resindex 1 or resindex 2":
+            return mol[1:3]
+        if q == "resindex 0 or resindex 1 or resindex 2":
+            return mol
+
+    mol.select_atoms.side_effect = _select_atoms
+
+    node._build_ua_vectors = MagicMock(
+        return_value=([np.array([1.0, 0.0, 0.0])], [np.array([0.0, 1.0, 0.0])])
+    )
+    node._ft.compute_frame_covariance = MagicMock(
+        return_value=(np.eye(3), 2.0 * np.eye(3))
+    )
+
+    out_force = {"ua": {}, "res": {}, "poly": {}}
+    out_torque = {"ua": {}, "res": {}, "poly": {}}
+    molcount = {}
+
+    node._process_united_atom(
+        u=universe,
+        mol=mol,
+        mol_id=0,
+        group_id=7,
+        beads={
+            (0, "united_atom", 0): [np.array([0])],
+            (0, "united_atom", 1): [np.array([1])],
+            (0, "united_atom", 2): [np.array([2])],
+        },
+        axes_manager="axes",
+        axes_topology=None,
+        box=None,
+        force_partitioning=0.5,
+        customised_axes=False,
+        is_highest=True,
+        out_force=out_force,
+        out_torque=out_torque,
+        molcount=molcount,
+    )
+
+    np.testing.assert_allclose(out_force["ua"][(7, 0), (7, 1), (7, 2)], np.eye(3))
+    np.testing.assert_allclose(
+        out_torque["ua"][(7, 0), (7, 1), (7, 2)], 2.0 * np.eye(3)
+    )

--- a/tests/unit/CodeEntropy/levels/test_axes.py
+++ b/tests/unit/CodeEntropy/levels/test_axes.py
@@ -1677,3 +1677,27 @@ def test_get_chain(monkeypatch):
     chain = ax.get_chain(residue=residue, first=heavy_atoms[0], last=heavy_atoms[-1])
 
     assert len(chain) == 3
+
+
+def test_get_UA_axes_raises_when_only_rot_axes_fail(monkeypatch):
+    ax = AxesCalculator()
+    u = MagicMock()
+    u.atoms.principal_axes.return_value = np.eye(3)
+    u.dimensions = np.array([10.0, 10.0, 10.0, 90, 90, 90])
+    residue = MagicMock()
+    u.residues = [residue]
+    heavy_atoms = [
+        _atom(index=0, mass=12.0, pos=(1, 0, 0)),
+        _atom(index=1, mass=12.0, pos=(0, 1, 0)),
+    ]
+
+    def _sel(q):
+        if q == "mass 2 to 999":
+            return heavy_atoms
+
+    u.select_atoms.side_effect = _sel
+    monkeypatch.setattr("CodeEntropy.levels.axes.make_whole", lambda _ag: None)
+    monkeypatch.setattr(ax, "get_bonded_axes", lambda **kwargs: (None, None))
+
+    with pytest.raises(ValueError):
+        ax.get_UA_axes(u, index=0, res_position=None)

--- a/tests/unit/CodeEntropy/levels/test_axes.py
+++ b/tests/unit/CodeEntropy/levels/test_axes.py
@@ -1246,7 +1246,7 @@ def test_get_custom_residue_moment_of_inertia(monkeypatch):
     assert moi.shape == (3,)
 
 
-def test_get_residue_bonded_axes_2neighbours(monkeypatch):
+def test_get_residue_bonded_axes_1_heavy_atom_backbone_2neighbours(monkeypatch):
     ax = AxesCalculator()
     u = MagicMock()
     u.dimensions = np.array([10.0, 10.0, 10.0, 90, 90, 90])
@@ -1270,6 +1270,54 @@ def test_get_residue_bonded_axes_2neighbours(monkeypatch):
     u.atoms.select_atoms.side_effect = _select_atoms
     u.atoms.principal_axes.return_value = np.eye(3)
     monkeypatch.setattr(ax, "get_chain", backbone_atom)
+    monkeypatch.setattr(
+        ax,
+        "get_custom_residue_moment_of_inertia",
+        lambda center_of_mass, positions, masses, custom_rot_axes, dimensions: np.array(
+            [1, 1, 1]
+        ),
+    )
+
+    trans_axes, rot_axes, rot_center, moi = ax.get_residue_axes(
+        u, index=1, relative_index=0
+    )
+
+    assert len(edge_atom_set) == 2
+    assert np.allclose(trans_axes, np.eye(3))
+    assert rot_axes.shape == (3, 3)
+    assert rot_center.shape == (3,)
+    assert np.allclose(moi, np.array([1, 1, 1]))
+
+
+def test_get_residue_bonded_axes_multiple_heavy_atoms_backbone_2neighbours(monkeypatch):
+    ax = AxesCalculator()
+    u = MagicMock()
+    u.dimensions = np.array([10.0, 10.0, 10.0, 90, 90, 90])
+    monkeypatch.setattr("CodeEntropy.levels.axes.make_whole", lambda _ag: None)
+    residue = u.select_atoms("resindex 1")
+    residue.__len__.return_value = 1
+
+    edge_atom_set = _FakeAtomGroup(
+        [
+            _atom(index=8, mass=12.0, pos=[1, 0, 0]),
+            _atom(index=12, mass=14.0, pos=[0, 0, 0]),
+        ],
+        positions=np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=float),
+    )
+    backbone_atoms = [
+        _atom(index=9, mass=12.0, pos=[0, 1, 0]),
+        _atom(index=10, mass=14.0, pos=[0, 2, 0]),
+    ]
+
+    def _select_atoms(q):
+        if q.endswith("(bonded resindex 0 or resindex 2)"):
+            return edge_atom_set
+
+    u.atoms.select_atoms.side_effect = _select_atoms
+    u.atoms.principal_axes.return_value = np.eye(3)
+    monkeypatch.setattr(
+        ax, "get_chain", lambda residue, edge_atom_1, edge_atom_2: backbone_atoms
+    )
     monkeypatch.setattr(
         ax,
         "get_custom_residue_moment_of_inertia",
@@ -1392,7 +1440,7 @@ def test_get_residue_bonded_axes_last_resid(monkeypatch):
     assert np.allclose(moi, np.array([1, 1, 1]))
 
 
-def test_get_ua_axes_bonded_axes_2neighbours(monkeypatch):
+def test_get_ua_axes_bonded_axes_2neighbours_1_heavy_atom_backbone(monkeypatch):
     ax = AxesCalculator()
     residue_group = MagicMock()
     residue_group.__len__ = 3
@@ -1427,6 +1475,60 @@ def test_get_ua_axes_bonded_axes_2neighbours(monkeypatch):
     residue_group.select_atoms.side_effect = _select_atoms
     residue.atoms.select_atoms.side_effect = _select_atoms
     monkeypatch.setattr(ax, "get_chain", lambda residue, first, last: heavy_atoms[1])
+    monkeypatch.setattr(
+        ax,
+        "get_bonded_axes",
+        lambda system, atom, dimensions: (np.eye(3), np.array([1.0, 2.0, 3.0])),
+    )
+
+    trans_axes, rot_axes, rot_center, moi = ax.get_UA_axes(
+        data_container=residue_group, index=1, res_position=0
+    )
+
+    assert trans_axes.shape == (3, 3)
+    assert rot_axes.shape == (3, 3)
+    assert moi.shape == (3,)
+    assert rot_center.shape == (3,)
+
+
+def test_get_ua_axes_bonded_axes_2neighbours_multiple_heavy_atoms_backbone(monkeypatch):
+    ax = AxesCalculator()
+    residue_group = MagicMock()
+    residue_group.__len__ = 3
+    residue = residue_group.residues[1]
+
+    heavy_atoms = _FakeAtomGroup(
+        [
+            _atom(index=3, mass=12.0, pos=(1, 0, 0)),
+            _atom(index=5, mass=12.0, pos=(0, 1, 0)),
+            _atom(index=7, mass=12.0, pos=(0, 0, 1)),
+            _atom(index=9, mass=12.0, pos=(0, 1, 1)),
+        ],
+        positions=np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1], [0, 1, 1]], dtype=float),
+    )
+
+    edge_atoms = _FakeAtomGroup(
+        [
+            _atom(index=3, mass=12.0, pos=(1, 0, 0)),
+            _atom(index=9, mass=12.0, pos=(0, 1, 1)),
+        ],
+        positions=np.array([[1, 0, 0], [0, 1, 1]], dtype=float),
+    )
+
+    def _select_atoms(q):
+        if q == "mass 2 to 999":
+            # return heavy atoms group
+            return heavy_atoms
+        if q.startswith("resindex "):
+            return edge_atoms
+        if q.startswith("index "):
+            return [heavy_atoms[1]]
+
+    residue_group.select_atoms.side_effect = _select_atoms
+    residue.atoms.select_atoms.side_effect = _select_atoms
+    monkeypatch.setattr(
+        ax, "get_chain", lambda residue, first, last: [heavy_atoms[1], heavy_atoms[2]]
+    )
     monkeypatch.setattr(
         ax,
         "get_bonded_axes",

--- a/tests/unit/CodeEntropy/levels/test_axes.py
+++ b/tests/unit/CodeEntropy/levels/test_axes.py
@@ -76,7 +76,7 @@ def test_get_residue_axes_empty_residue_raises():
     u.select_atoms.return_value = []
 
     with pytest.raises(ValueError):
-        ax.get_residue_axes(u, index=5)
+        ax.get_residue_axes(u, index=5, relative_index=0)
 
 
 def test_get_residue_axes_no_bonds_uses_custom_principal_axes(monkeypatch):
@@ -110,7 +110,7 @@ def test_get_residue_axes_no_bonds_uses_custom_principal_axes(monkeypatch):
         lambda moi: (np.eye(3), np.array([3.0, 2.0, 1.0])),
     )
 
-    trans, rot, center, moi = ax.get_residue_axes(u, index=7)
+    trans, rot, center, moi = ax.get_residue_axes(u, index=7, relative_index=0)
 
     assert np.allclose(trans, np.eye(3))
     assert np.allclose(rot, np.eye(3))
@@ -145,7 +145,7 @@ def test_get_residue_axes_with_bonds_uses_vanilla_axes(monkeypatch):
         ax, "get_vanilla_axes", lambda mol: (np.eye(3) * 2, np.array([9.0, 8.0, 7.0]))
     )
 
-    trans, rot, center, moi = ax.get_residue_axes(u, index=10)
+    trans, rot, center, moi = ax.get_residue_axes(u, index=10, relative_index=0)
 
     assert np.allclose(trans, np.eye(3))
     assert np.allclose(rot, np.eye(3) * 2)
@@ -154,17 +154,18 @@ def test_get_residue_axes_with_bonds_uses_vanilla_axes(monkeypatch):
 
 def test_get_UA_axes_uses_principal_axes_when_single_heavy(monkeypatch):
     ax = AxesCalculator()
-
     u = MagicMock()
     u.dimensions = np.array([10.0, 10.0, 10.0, 90, 90, 90])
     u.atoms.principal_axes.return_value = np.eye(3)
+    u.center_of_mass.return_value = np.array([[4.0, 0.0, 0.0]])
 
     # heavy_atoms length <= 1 => principal_axes path
-    heavy_atom = MagicMock(index=5)
+    heavy_atom = MagicMock(index=5, position=np.array([4.0, 0.0, 0.0]))
     heavy_atoms = [heavy_atom]
 
     def _sel(q):
-        if q == "prop mass > 1.1":
+        if q == "mass 2 to 999":
+            # return heavy atoms group
             return heavy_atoms
         if q.startswith("index "):
             # return atom group with positions
@@ -173,6 +174,7 @@ def test_get_UA_axes_uses_principal_axes_when_single_heavy(monkeypatch):
             ag.__getitem__.return_value = MagicMock(
                 mass=12.0, position=np.array([4.0, 0.0, 0.0]), index=5
             )
+
             return ag
         return []
 
@@ -185,7 +187,7 @@ def test_get_UA_axes_uses_principal_axes_when_single_heavy(monkeypatch):
         lambda system, atom, dimensions: (np.eye(3), np.array([1.0, 2.0, 3.0])),
     )
 
-    trans, rot, center, moi = ax.get_UA_axes(u, index=0)
+    trans, rot, center, moi = ax.get_UA_axes(u, index=0, res_position=None)
 
     assert np.allclose(trans, np.eye(3))
     assert np.allclose(rot, np.eye(3))
@@ -202,7 +204,7 @@ def test_get_UA_axes_raises_when_bonded_axes_fail(monkeypatch):
     heavy_atoms = [heavy_atom]
 
     def _sel(q):
-        if q == "prop mass > 1.1":
+        if q == "mass 2 to 999":
             return heavy_atoms
         if q.startswith("index "):
             ag = MagicMock()
@@ -218,7 +220,7 @@ def test_get_UA_axes_raises_when_bonded_axes_fail(monkeypatch):
     monkeypatch.setattr(ax, "get_bonded_axes", lambda **kwargs: (None, None))
 
     with pytest.raises(ValueError):
-        ax.get_UA_axes(u, index=0)
+        ax.get_UA_axes(u, index=5, res_position=None)
 
 
 def test_get_custom_axes_degenerate_axis1_raises():
@@ -497,7 +499,7 @@ def test_get_residue_axes_no_bonds_custom_path(monkeypatch):
         lambda moi: (np.eye(3), np.array([3.0, 2.0, 1.0])),
     )
 
-    trans, rot, center, moi = ax.get_residue_axes(u, index=7)
+    trans, rot, center, moi = ax.get_residue_axes(u, index=7, relative_index=0)
 
     assert trans.shape == (3, 3)
     assert rot.shape == (3, 3)
@@ -532,7 +534,7 @@ def test_get_residue_axes_with_bonds_vanilla_path(monkeypatch):
         ax, "get_vanilla_axes", lambda mol: (np.eye(3) * 2, np.array([9.0, 8.0, 7.0]))
     )
 
-    trans, rot, center, moi = ax.get_residue_axes(u, index=10)
+    trans, rot, center, moi = ax.get_residue_axes(u, index=10, relative_index=0)
 
     assert np.allclose(trans, np.eye(3) * 2)
     assert np.allclose(rot, np.eye(3) * 2)
@@ -621,13 +623,13 @@ def test_get_UA_axes_multiple_heavy_atoms_uses_custom_principal_axes(monkeypatch
 
     heavy_atoms = _FakeAtomGroup(
         [
-            _FakeAtom(0, 12.0, [0, 0, 0]),
-            _FakeAtom(1, 12.0, [1, 0, 0]),
+            _atom(index=0, mass=12.0, pos=[0, 0, 0]),
+            _atom(index=1, mass=12.0, pos=[1, 0, 0]),
         ],
         positions=np.array([[0, 0, 0], [1, 0, 0]], dtype=float),
     )
 
-    system_atom = _FakeAtom(index=0, mass=12.0, position=[0, 0, 0])
+    system_atom = _atom(index=0, mass=12.0, pos=[0, 0, 0])
     heavy_atom_selection = _FakeAtomGroup(
         [system_atom], positions=np.array([[0, 0, 0]], dtype=float)
     )
@@ -639,12 +641,23 @@ def test_get_UA_axes_multiple_heavy_atoms_uses_custom_principal_axes(monkeypatch
         def __getitem__(self, idx):
             return system_atom
 
+        def principal_axes(self, *args, **kwargs):
+            return np.eye(3)
+
+        def select_atoms(self, q):
+            if q == "mass 2 to 999":
+                return heavy_atoms
+            if q.startswith("index "):
+                return [heavy_atom_selection[0]]
+
     data_container = MagicMock()
     data_container.atoms = _Atoms()
+    data_container.residues.__len__.return_value = 1
     data_container.dimensions = np.array([10.0, 10.0, 10.0, 90, 90, 90], dtype=float)
+    _FakeAtomGroup.atoms = heavy_atom_selection
 
     def _select_atoms(q):
-        if q == "prop mass > 1.1":
+        if q == "mass 2 to 999":
             return heavy_atoms
         if q.startswith("index "):
             return heavy_atom_selection
@@ -659,20 +672,14 @@ def test_get_UA_axes_multiple_heavy_atoms_uses_custom_principal_axes(monkeypatch
     )
     monkeypatch.setattr(ax, "get_UA_masses", lambda _ag: [12.0, 12.0])
 
-    got_tensor = MagicMock(return_value=np.eye(3))
-    monkeypatch.setattr(ax, "get_moment_of_inertia_tensor", got_tensor)
-
-    got_custom_axes = MagicMock(return_value=(np.eye(3), np.array([3.0, 2.0, 1.0])))
-    monkeypatch.setattr(ax, "get_custom_principal_axes", got_custom_axes)
-
-    trans_axes, rot_axes, center, moi = ax.get_UA_axes(data_container, index=0)
+    trans_axes, rot_axes, center, moi = ax.get_UA_axes(
+        data_container, index=0, res_position=None
+    )
 
     assert trans_axes.shape == (3, 3)
     assert rot_axes.shape == (3, 3)
     assert np.allclose(center, np.array([0.0, 0.0, 0.0]))
     assert moi.shape == (3,)
-    got_tensor.assert_called_once()
-    got_custom_axes.assert_called_once()
 
 
 def test_get_bonded_axes_returns_none_none_if_custom_axes_none(monkeypatch):
@@ -1196,3 +1203,370 @@ def test_get_bonded_axes_from_topology_returns_none_when_custom_axes_none(
     assert moi is None
     get_custom_moi.assert_not_called()
     get_flipped.assert_not_called()
+
+
+def test_get_residue_axes_custom_path(monkeypatch):
+    ax = AxesCalculator()
+
+    edge_atoms = _FakeAtomGroup(
+        [_FakeAtom(8, 12.0, [1, 0, 0]), _FakeAtom(10, 14.0, [0, 0, 0])],
+        positions=np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=float),
+    )
+
+    backbone_center = np.array([0.0, 1.0, 0.0])
+    rot_center, rot_axes = ax.get_residue_custom_axes(
+        [edge_atoms[0], edge_atoms[1]], backbone_center
+    )
+
+    assert rot_center.shape == (3,)
+    assert rot_axes.shape == (3, 3)
+
+
+def test_get_custom_residue_moment_of_inertia(monkeypatch):
+    ax = AxesCalculator()
+    heavy_atoms = _FakeAtomGroup(
+        [_FakeAtom(0, 12.0, [1, 2, 1]), _FakeAtom(1, 12.0, [2, 1, 1])],
+        positions=np.array([[1, 2, 1], [2, 1, 1]], dtype=float),
+    )
+    dimensions = np.array([10.0, 10.0, 10.0], dtype=float)
+
+    moi = ax.get_custom_residue_moment_of_inertia(
+        center_of_mass=np.array([1, 1, 1]),
+        positions=heavy_atoms.positions,
+        masses=heavy_atoms.masses,
+        custom_rot_axes=np.eye(3),
+        dimensions=dimensions,
+    )
+
+    assert moi.shape == (3,)
+
+
+def test_get_residue_bonded_axes_2neighbours(monkeypatch):
+    ax = AxesCalculator()
+    u = MagicMock()
+    u.dimensions = np.array([10.0, 10.0, 10.0, 90, 90, 90])
+    monkeypatch.setattr("CodeEntropy.levels.axes.make_whole", lambda _ag: None)
+    residue = u.select_atoms("resindex 1")
+    residue.__len__.return_value = 1
+
+    edge_atom_set = _FakeAtomGroup(
+        [
+            _atom(index=8, mass=12.0, pos=[1, 0, 0]),
+            _atom(index=10, mass=14.0, pos=[0, 0, 0]),
+        ],
+        positions=np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=float),
+    )
+    backbone_atom = _atom(index=9, mass=12.0, pos=[0, 1, 0])
+
+    def _select_atoms(q):
+        if q.endswith("(bonded resindex 0 or resindex 2)"):
+            return edge_atom_set
+
+    u.atoms.select_atoms.side_effect = _select_atoms
+    u.atoms.principal_axes.return_value = np.eye(3)
+    monkeypatch.setattr(ax, "get_chain", backbone_atom)
+    monkeypatch.setattr(
+        ax,
+        "get_custom_residue_moment_of_inertia",
+        lambda center_of_mass, positions, masses, custom_rot_axes, dimensions: np.array(
+            [1, 1, 1]
+        ),
+    )
+
+    trans_axes, rot_axes, rot_center, moi = ax.get_residue_axes(
+        u, index=1, relative_index=0
+    )
+
+    assert len(edge_atom_set) == 2
+    assert np.allclose(trans_axes, np.eye(3))
+    assert rot_axes.shape == (3, 3)
+    assert rot_center.shape == (3,)
+    assert np.allclose(moi, np.array([1, 1, 1]))
+
+
+def test_get_residue_bonded_axes_first_resid(monkeypatch):
+    ax = AxesCalculator()
+    u = MagicMock()
+    u.dimensions = np.array([10.0, 10.0, 10.0, 90, 90, 90])
+    monkeypatch.setattr("CodeEntropy.levels.axes.make_whole", lambda _ag: None)
+    residue = u.select_atoms("resindex 0")
+    residue.__len__.return_value = 3
+    residue.atoms = _FakeAtomGroup(
+        [
+            _atom(index=0, mass=12.0, pos=[1, 0, 0]),
+            _atom(index=1, mass=12.0, pos=[0, 1, 0]),
+            _atom(index=2, mass=12.0, pos=[0, 0, 0]),
+        ]
+    )
+    edge_atom_set = _FakeAtomGroup(
+        [
+            _atom(index=2, mass=12.0, pos=[0, 0, 0]),
+        ]
+    )
+
+    def _select_atoms(q):
+        if q.endswith("(bonded resindex -1 or resindex 1)"):
+            return edge_atom_set
+
+    backbone_atom = residue.atoms[1]
+    u.atoms.principal_axes.return_value = np.eye(3)
+    u.atoms.select_atoms.side_effect = _select_atoms
+    monkeypatch.setattr(ax, "get_chain", backbone_atom)
+    monkeypatch.setattr(
+        ax,
+        "get_custom_residue_moment_of_inertia",
+        lambda center_of_mass, positions, masses, custom_rot_axes, dimensions: np.array(
+            [1, 1, 1]
+        ),
+    )
+
+    trans_axes, rot_axes, rot_center, moi = ax.get_residue_axes(
+        u, index=0, relative_index=0
+    )
+
+    assert len(edge_atom_set) == 1
+    assert np.allclose(trans_axes, np.eye(3))
+    assert rot_axes.shape == (3, 3)
+    assert rot_center.shape == (3,)
+    assert np.allclose(moi, np.array([1, 1, 1]))
+
+
+def test_get_residue_bonded_axes_last_resid(monkeypatch):
+    ax = AxesCalculator()
+    u = MagicMock()
+    u.dimensions = np.array([10.0, 10.0, 10.0, 90, 90, 90])
+    monkeypatch.setattr("CodeEntropy.levels.axes.make_whole", lambda _ag: None)
+    residue = u.select_atoms("resindex 2")
+    residue.__len__.return_value = 3
+    heavy_atoms = _FakeAtomGroup(
+        [
+            _atom(index=4, mass=12.0, pos=[1, 0, 0]),
+            _atom(index=5, mass=12.0, pos=[0, 1, 0]),
+            _atom(index=6, mass=12.0, pos=[0, 0, 0]),
+        ]
+    )
+    edge_atom_set = _FakeAtomGroup(
+        [
+            _atom(index=4, mass=12.0, pos=[0, 0, 0]),
+        ]
+    )
+
+    def _select_atoms(q):
+        if q == "mass 2 to 999":
+            # return heavy atoms group
+            return heavy_atoms
+        if q.endswith("(bonded resindex 1 or resindex 3)"):
+            return edge_atom_set
+        if q == ("(mass 2 to 999) and bonded index 6"):
+            return [heavy_atoms[1]]
+        if q == ("(mass 2 to 999) and bonded index 5"):
+            return [heavy_atoms[0], heavy_atoms[2]]
+
+    backbone_atom = heavy_atoms[1]
+    u.atoms.principal_axes.return_value = np.eye(3)
+    u.atoms.select_atoms.side_effect = _select_atoms
+    residue.select_atoms.side_effect = _select_atoms
+    residue.atoms.select_atoms.side_effect = _select_atoms
+    monkeypatch.setattr(ax, "get_chain", backbone_atom)
+    monkeypatch.setattr(
+        ax,
+        "get_custom_residue_moment_of_inertia",
+        lambda center_of_mass, positions, masses, custom_rot_axes, dimensions: np.array(
+            [1, 1, 1]
+        ),
+    )
+
+    trans_axes, rot_axes, rot_center, moi = ax.get_residue_axes(
+        u, index=2, relative_index=0
+    )
+
+    assert len(edge_atom_set) == 1
+    assert np.allclose(trans_axes, np.eye(3))
+    assert rot_axes.shape == (3, 3)
+    assert rot_center.shape == (3,)
+    assert np.allclose(moi, np.array([1, 1, 1]))
+
+
+def test_get_ua_axes_bonded_axes_2neighbours(monkeypatch):
+    ax = AxesCalculator()
+    residue_group = MagicMock()
+    residue_group.__len__ = 3
+    residue = residue_group.residues[1]
+
+    heavy_atoms = _FakeAtomGroup(
+        [
+            _atom(index=3, mass=12.0, pos=(1, 0, 0)),
+            _atom(index=5, mass=12.0, pos=(0, 1, 0)),
+            _atom(index=7, mass=12.0, pos=(0, 0, 1)),
+        ],
+        positions=np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float),
+    )
+
+    edge_atoms = _FakeAtomGroup(
+        [
+            _atom(index=3, mass=12.0, pos=(1, 0, 0)),
+            _atom(index=7, mass=12.0, pos=(0, 0, 1)),
+        ],
+        positions=np.array([[1, 0, 0], [0, 0, 1]], dtype=float),
+    )
+
+    def _select_atoms(q):
+        if q == "mass 2 to 999":
+            # return heavy atoms group
+            return heavy_atoms
+        if q.startswith("resindex "):
+            return edge_atoms
+        if q.startswith("index "):
+            return [heavy_atoms[1]]
+
+    residue_group.select_atoms.side_effect = _select_atoms
+    residue.atoms.select_atoms.side_effect = _select_atoms
+    monkeypatch.setattr(ax, "get_chain", lambda residue, first, last: heavy_atoms[1])
+    monkeypatch.setattr(
+        ax,
+        "get_bonded_axes",
+        lambda system, atom, dimensions: (np.eye(3), np.array([1.0, 2.0, 3.0])),
+    )
+
+    trans_axes, rot_axes, rot_center, moi = ax.get_UA_axes(
+        data_container=residue_group, index=1, res_position=0
+    )
+
+    assert trans_axes.shape == (3, 3)
+    assert rot_axes.shape == (3, 3)
+    assert moi.shape == (3,)
+    assert rot_center.shape == (3,)
+
+
+def test_get_ua_axes_bonded_axes_first_resid(monkeypatch):
+    ax = AxesCalculator()
+    residue_group = MagicMock()
+    residue_group.__len__ = 2
+    residue = residue_group.residues[0]
+    heavy_atoms = _FakeAtomGroup(
+        [
+            _atom(index=0, mass=12.0, pos=(1, 0, 0)),
+            _atom(index=1, mass=12.0, pos=(0, 1, 0)),
+            _atom(index=2, mass=12.0, pos=(0, 0, 1)),
+        ],
+    )
+
+    residue.atoms[0] = heavy_atoms[0]
+    residue.atoms[0].position = heavy_atoms[0].position
+    edge_atom_set = _FakeAtomGroup(
+        [
+            _atom(index=2, mass=12.0, pos=(0, 0, 1)),
+        ],
+    )
+
+    def _select_atoms(q):
+        if q == "mass 2 to 999":
+            # return heavy atoms group
+            return heavy_atoms
+        if q.startswith("resindex "):
+            return edge_atom_set
+        if q.startswith("index "):
+            return [heavy_atoms[0]]
+
+    residue_group.select_atoms.side_effect = _select_atoms
+    residue.atoms.select_atoms.side_effect = _select_atoms
+    edge_atom_set.atoms = [edge_atom_set[0]]
+    monkeypatch.setattr(ax, "get_chain", lambda residue, first, last: heavy_atoms[1])
+    monkeypatch.setattr(
+        ax,
+        "get_bonded_axes",
+        lambda system, atom, dimensions: (np.eye(3), np.array([1.0, 1.0, 1.0])),
+    )
+    trans_axes, rot_axes, rot_center, moi = ax.get_UA_axes(
+        data_container=residue_group, index=0, res_position=-1
+    )
+
+    assert trans_axes.shape == (3, 3)
+    assert rot_axes.shape == (3, 3)
+    assert moi.shape == (3,)
+    assert rot_center.shape == (3,)
+
+
+def test_get_ua_axes_bonded_axes_last_resid(monkeypatch):
+    ax = AxesCalculator()
+    residue_group = MagicMock()
+    residue_group.__len__ = 2
+    residue = residue_group.residues[1]
+    heavy_atoms = _FakeAtomGroup(
+        [
+            _atom(index=0, mass=12.0, pos=(1, 0, 0)),
+            _atom(index=1, mass=12.0, pos=(0, 1, 0)),
+            _atom(index=2, mass=12.0, pos=(0, 0, 1)),
+        ],
+    )
+
+    edge_atom_set = _FakeAtomGroup(
+        [
+            _atom(index=0, mass=12.0, pos=(1, 0, 0)),
+        ],
+    )
+
+    def _select_atoms(q):
+        if q == "mass 2 to 999":
+            # return heavy atoms group
+            return heavy_atoms
+        if q.startswith("resindex "):
+            return edge_atom_set
+        if q.startswith("index "):
+            return [heavy_atoms[0]]
+        if q == ("(mass 2 to 999) and bonded index 2"):
+            return [heavy_atoms[1]]
+        if q == ("(mass 2 to 999) and bonded index 1"):
+            return [heavy_atoms[0], heavy_atoms[2]]
+
+    residue_group.select_atoms.side_effect = _select_atoms
+    residue.atoms.select_atoms.side_effect = _select_atoms
+    edge_atom_set.atoms = [edge_atom_set[0]]
+    monkeypatch.setattr(ax, "get_chain", lambda residue, first, last: heavy_atoms[1])
+    monkeypatch.setattr(
+        ax,
+        "get_bonded_axes",
+        lambda system, atom, dimensions: (np.eye(3), np.array([1.0, 1.0, 1.0])),
+    )
+    trans_axes, rot_axes, rot_center, moi = ax.get_UA_axes(
+        data_container=residue_group, index=0, res_position=1
+    )
+
+    assert trans_axes.shape == (3, 3)
+    assert rot_axes.shape == (3, 3)
+    assert moi.shape == (3,)
+    assert rot_center.shape == (3,)
+
+
+def test_get_chain(monkeypatch):
+    ax = AxesCalculator()
+    residue = MagicMock()
+    residue.__len__ = 5
+    heavy_atoms = [
+        _atom(index=0, mass=12.0, pos=(1, 0, 0)),
+        _atom(index=1, mass=12.0, pos=(0, 1, 0)),
+        _atom(index=2, mass=12.0, pos=(0, 0, 1)),
+        _atom(index=3, mass=12.0, pos=(0, 1, 1)),
+        _atom(index=4, mass=12.0, pos=(1, 0, 1)),
+    ]
+
+    def _select_atoms(q):
+        if q.endswith("bonded index 0"):
+            return [heavy_atoms[1]]
+        elif q.endswith("bonded index 1"):
+            return [heavy_atoms[0], heavy_atoms[2]]
+        elif q.endswith("bonded index 2"):
+            return [heavy_atoms[1], heavy_atoms[3]]
+        elif q.endswith("bonded index 3"):
+            return [heavy_atoms[2], heavy_atoms[4]]
+        elif q.endswith("bonded index 4"):
+            return [heavy_atoms[3]]
+        elif q.endswith("not index 0"):
+            return heavy_atoms[1:]
+
+    residue.atoms.select_atoms.side_effect = _select_atoms
+    residue.atoms.indices = np.arange(5)
+
+    chain = ax.get_chain(residue=residue, first=heavy_atoms[0], last=heavy_atoms[-1])
+
+    assert len(chain) == 3

--- a/tests/unit/CodeEntropy/levels/test_axes.py
+++ b/tests/unit/CodeEntropy/levels/test_axes.py
@@ -118,7 +118,7 @@ def test_get_residue_axes_no_bonds_uses_custom_principal_axes(monkeypatch):
     assert np.allclose(moi, np.array([3.0, 2.0, 1.0]))
 
 
-def test_get_residue_axes_with_bonds_uses_vanilla_axes(monkeypatch):
+def test_get_residue_axes_one_residue_uses_principal_axes(monkeypatch):
     ax = AxesCalculator()
 
     residue = MagicMock()
@@ -142,13 +142,15 @@ def test_get_residue_axes_with_bonds_uses_vanilla_axes(monkeypatch):
 
     monkeypatch.setattr("CodeEntropy.levels.axes.make_whole", lambda _ag: None)
     monkeypatch.setattr(
-        ax, "get_vanilla_axes", lambda mol: (np.eye(3) * 2, np.array([9.0, 8.0, 7.0]))
+        ax,
+        "get_moment_of_inertia_tensor",
+        lambda **kwargs: np.array([[9.0, 0.0, 0.0], [0.0, 8.0, 0.0], [0.0, 0.0, 7.0]]),
     )
 
     trans, rot, center, moi = ax.get_residue_axes(u, index=10, relative_index=0)
 
     assert np.allclose(trans, np.eye(3))
-    assert np.allclose(rot, np.eye(3) * 2)
+    assert np.allclose(rot, np.eye(3))
     assert np.allclose(moi, np.array([9.0, 8.0, 7.0]))
 
 
@@ -507,7 +509,7 @@ def test_get_residue_axes_no_bonds_custom_path(monkeypatch):
     assert np.allclose(moi, np.array([3.0, 2.0, 1.0]))
 
 
-def test_get_residue_axes_with_bonds_vanilla_path(monkeypatch):
+def test_get_residue_axes_one_residue_principal_axes_path(monkeypatch):
     ax = AxesCalculator()
 
     residue = MagicMock()
@@ -530,14 +532,17 @@ def test_get_residue_axes_with_bonds_vanilla_path(monkeypatch):
     u.select_atoms.side_effect = _select_atoms
 
     monkeypatch.setattr("CodeEntropy.levels.axes.make_whole", lambda _ag: None)
+
     monkeypatch.setattr(
-        ax, "get_vanilla_axes", lambda mol: (np.eye(3) * 2, np.array([9.0, 8.0, 7.0]))
+        ax,
+        "get_moment_of_inertia_tensor",
+        lambda **kwargs: np.array([[9.0, 0.0, 0.0], [0.0, 8.0, 0.0], [0.0, 0.0, 7.0]]),
     )
 
     trans, rot, center, moi = ax.get_residue_axes(u, index=10, relative_index=0)
 
-    assert np.allclose(trans, np.eye(3) * 2)
-    assert np.allclose(rot, np.eye(3) * 2)
+    assert np.allclose(trans, np.eye(3))
+    assert np.allclose(rot, np.eye(3))
     assert np.allclose(center, np.array([1.0, 2.0, 3.0]))
     assert np.allclose(moi, np.array([9.0, 8.0, 7.0]))
 


### PR DESCRIPTION
## Summary
This PR addresses issues #26, #279, and #370 and introduces custom axes for residue level rotations/UA level translations.

## Changes
- DataContainer at the residue level now consists of the residue of interest alongside its neighbours. The residue_group data container contains two residues for the first and last residue (residue + the one neighbours), or three residues otherwise (residue + 2 neighbours).

- When selection does not start with first residue in topology, indexing of residue in topology, i.e. index with respect to first residue in topology, is accounted for.

- Translation axes at UA level for molecules with multiple residues, are calculated the same way as residue level rotation axes.

- New function _get_chain_ in axes.py that identifies the shortest heavy-atom path between two heavy atoms in a given residue and returns only the heavy atoms in between. This is used to define the backbone of a residue as the shortest path between heavy atoms bonded to neighbouring residues. For the first residue, it uses the first atom in the residue as the starting point, and for the last residue, it uses the last heavy atom with only one bond to another heavy atom as the ending point. 
For a protein, it finds the N,CA,C atoms. (+ O in the case of the last residue.) as the backbone, and returns the CA (+C) atom(s) as the in between atoms.
For a DNA molecule, it finds the chain shown in purple. 
<img width="452" height="287" alt="Screenshot 2026-04-13 092733" src="https://github.com/user-attachments/assets/a6cea694-10dc-4ba2-b9c7-e57b5e092bb4" />
<img width="1844" height="49" alt="protein_backbone_output" src="https://github.com/user-attachments/assets/31a6129e-a41e-43b1-a33a-c53457694ece" />
<img width="855" height="123" alt="DNA_backbone_output" src="https://github.com/user-attachments/assets/9cd44808-e599-41c8-b900-f5c257a2fdda" />
<img width="292" height="228" alt="DNA_backbone_structure" src="https://github.com/user-attachments/assets/85d917c8-5242-4144-9d9c-edb084cc6a2c" />

 - New function _get_custom_residue_moment_of_inertia_ to calculate residue MOI in the coordinate frame of the custom rotation axes.
 
 - New function _get_residue_custom_axes_ which computes the coordinate frame for a residue based on the two edge atoms (heavy atoms linearly bonded to neighbouring atoms) and centre of geometry of backbone atoms in between the edges.
<img width="2808" height="2009" alt="new_residue_axes" src="https://github.com/user-attachments/assets/ce4ef4a4-3c3f-4d3e-beb2-cffdba77631b" />

- Unit tests in test_axes.py and test_covariance_node.py were adapted to accommodate new residue axes and residue groups.
- Regression baselines were updated to account for changes.
- New unit tests have been added.
- Text in the Vibrational Entropy subsection of the Multiscale Cell Correlation Theory section of the documentation has been changed to reflect changes.

## Impact

- Closes #26, #279 and #370. 
- UA translation axes always match residue rotation axes. This should mean that translations and rotations at the residue level are correctly discarded when calculating UA transvibrational entropy. 
- Center of residue is now located along backbone. The backbone can be identified for any molecule with bonded residues. This leads to higher entropy values than using the residue centre of mass as before with principal axes.
- Entropy values are similar to values using the NCC axes. New axes will be equivalent to NCC for a protein, with the exception of the last residue.
<img width="524" height="224" alt="image" src="https://github.com/user-attachments/assets/dc2af7e0-8c47-477c-ad5b-d62c274a4e13" />
<img width="492" height="210" alt="image" src="https://github.com/user-attachments/assets/19f50976-1e8a-46bf-8cd1-5aeb6d925abd" />


-  The coordinate system is general and suitable for molecules such as DNA.
## Future work
- Argument for the users to choose between heavy MDAnalysis dependant axes (this implementation) and cached topology axes (still uses principal axes) will be added. At the moment, default is the cached topology axes.
- A coordinate system that does not depend on indices will be chosen for terminal residues.
- Branched residues will be dealt with. 
- If we decide on an external definition for residue axes, there might be slight changes but they would be smaller changes than this.
