### PR TITLE
Update Flit release tooling to v4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -138,11 +138,11 @@ jobs:
     - name: Install flit
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flit~=3.9
+        python -m pip install "flit>=4,<5" "flit_core>=4,<5"
 
     - name: Build and publish
       run: |
-        flit publish
+        flit publish --use-vcs
       env:
         FLIT_USERNAME: __token__
         FLIT_PASSWORD:  ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Build the package with [flit](https://flit.readthedocs.io)
-requires = ["flit_core >=3.4,<4"]
+requires = ["flit_core >=4,<5"]
 build-backend = "flit_core.buildapi"
 
 [project]


### PR DESCRIPTION
## Summary
This PR updates the release tooling to Flit 4 to fix the PyPI publishing failure caused by Flit 3 resolving against the newly released `flit_core` 4.x. The two major versions are incompatible, resulting in `flit publish` failing while building the source distribution.

## Changes
### Flit configuration:

* Updated the release workflow to use `flit>=4,<5` and `flit_core>=4,<5`.
* Updated the build-system requirement to `flit_core>=4,<5`.
* Added `--use-vcs` to `flit publish` to preserve the existing source distribution behaviour under Flit 4.

## Impact
* Restores PyPI publishing by keeping `flit` and `flit_core` on compatible major versions.
* Prevents future major `flit_core` releases from being pulled into the current Flit release line unexpectedly.
* Preserves the existing VCS-based source distribution behaviour.