### PR TITLE
Update conda recipe to Flit Core 4

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
   host:
     - python >=3.12
     - pip
-    - flit-core >=3.4,<4
+    - flit-core >=4,<5
   run:
     - python >=3.12
     - numpy >=2.3,<3.0


### PR DESCRIPTION
## Summary

This PR updates the conda recipe to use Flit Core 4, keeping the conda build dependency aligned with the project’s updated build-system requirements.

## Changes

### Conda build dependency:

* Updated `flit-core` from `>=3.4,<4` to `>=4,<5` in `conda-recipe/meta.yaml`.

## Impact

* Keeps the conda build environment consistent with the Flit 4 configuration used by the project.
* Prevents the conda recipe from continuing to constrain builds to Flit Core 3.