### PR TITLE
Fix typo in topic name from 'announcement' to 'announcements'

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,7 +113,7 @@ jobs:
     steps:
       - name: create release
         id: create_release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           name: v${{ github.event.inputs.version }}
           generate_release_notes: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -151,7 +151,7 @@ jobs:
           curl -sSf "${ZULIP_SITE}/api/v1/messages" \
             -u "${ZULIP_BOT_EMAIL}:${ZULIP_BOT_API_KEY}" \
             --data-urlencode type=stream \
-            --data-urlencode "to=announcement" \
+            --data-urlencode "to=announcements" \
             --data-urlencode "topic=software releases" \
             --data-urlencode "content=${CONTENT}"
 


### PR DESCRIPTION
## Summary
Bug in the channel name has singular "announcement instead" of plural "announcements"

## Impact
Notifier should work now since zulip reported it arrived but that it arrived to a channel that did not exist.
