### PR TITLE
Update gh release command to specify repository

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,7 +128,7 @@ jobs:
         run: |
           # generate_release_notes builds the changelog server-side, so pull
           # it back down here rather than trying to reconstruct it locally.
-          gh release view "${{ github.event.inputs.version }}" --json body -q .body > changelog.txt
+          gh release view "${{ github.event.inputs.version }}" --repo "${{ github.repository }}" --json body -q .body > changelog.txt
 
       - name: notify Zulip of release
         if: steps.create_release.outcome == 'success'


### PR DESCRIPTION
## Summary
Add repo scope to gh release view query to properly scope the call to get the release body text.

## Impact
full report shows up correctly in zulip