### PR TITLE
Residue rotation and UA translation axes for terminal residues

### DIFF
--- a/CodeEntropy/levels/axes.py
+++ b/CodeEntropy/levels/axes.py
@@ -80,20 +80,20 @@ class AxesCalculator:
 
         - If bonded to only one other residue:
             * Translational axes are principal axes of data_container.
-            * Find edge heavy atom (i.e. heavy atoms bonded to next residue). Find
-            all heavy atoms bonded to edge heavy atom and compute their average
-            position. Find all other heavy atoms in residue and compute their average
-            position.The three points are now used to obtain determine residue
-            rotational axes. (see get_residue_custom_axes) Compute a custom MOI,
-            using heavy atom positions and heavy atom + hydrogen masses.
+            * Find edge heavy atom (i.e. heavy atoms bonded to neighbour residue). Find
+              all heavy atoms bonded to edge heavy atom and compute their average
+              position. Find all other heavy atoms in residue and compute their average
+              position.The three points are now used to obtain determine residue
+              rotational axes. (see get_residue_custom_axes) Compute a custom MOI,
+              using heavy atom positions and heavy atom + hydrogen masses.
 
         - If bonded to at least two other residues:
             * Translational axes are principal axes of data_container.
             * Find edge heavy atoms (i.e. heavy atoms bonded to neighbour residues)
-            and find the shortest chain between them: the backbone. Edge atoms
-            + backbone COM are used to determine residue rotational axes.
-            (see get_residue_custom_axes). Compute a custom MOI, using heavy
-            atom positions and heavy atom + hydrogen masses.
+              and find the shortest chain between them: the backbone. Edge atoms
+              + backbone COM are used to determine residue rotational axes.
+              (see get_residue_custom_axes). Compute a custom MOI, using heavy
+              atom positions and heavy atom + hydrogen masses.
 
         Args:
             data_container (MDAnalysis.Universe or AtomGroup):

--- a/CodeEntropy/levels/axes.py
+++ b/CodeEntropy/levels/axes.py
@@ -80,8 +80,8 @@ class AxesCalculator:
 
         - If bonded to only one other residue:
             * Translational axes are principal axes of data_container.
-            * Find edge heavy atom (i.e. heavy atoms bonded to neighbour residue).
-            Find all heavy atoms bonded to edge heavy atom and compute their average
+            * Find edge heavy atom (i.e. heavy atoms bonded to next residue). Find
+            all heavy atoms bonded to edge heavy atom and compute their average
             position. Find all other heavy atoms in residue and compute their average
             position.The three points are now used to obtain determine residue
             rotational axes. (see get_residue_custom_axes) Compute a custom MOI,
@@ -90,8 +90,8 @@ class AxesCalculator:
         - If bonded to at least two other residues:
             * Translational axes are principal axes of data_container.
             * Find edge heavy atoms (i.e. heavy atoms bonded to neighbour residues)
-            and find the shortest chain between them: the backbone. Edge
-            atoms + backbone COM are used to determine residue rotational axes.
+            and find the shortest chain between them: the backbone. Edge atoms
+            + backbone COM are used to determine residue rotational axes.
             (see get_residue_custom_axes). Compute a custom MOI, using heavy
             atom positions and heavy atom + hydrogen masses.
 

--- a/CodeEntropy/levels/axes.py
+++ b/CodeEntropy/levels/axes.py
@@ -80,28 +80,16 @@ class AxesCalculator:
 
         - If bonded to only one other residue:
             * Translational axes are principal axes of data_container.
-            * Find edge heavy atom (i.e. heavy atoms bonded to neighbour residue). Find
-              all heavy atoms bonded to edge heavy atom and compute their average
-              position. Find all other heavy atoms in residue and compute their average
-              position.The three points are now used to obtain determine residue
-              rotational axes. (see get_residue_custom_axes) If there are
-              only two heavy atoms in the residue/all heavy atoms are bonded to edge
-              atom, x-axis is set along the vector between the edge atom and average
-              position of bonded atoms, y-axis is arbitrary and z-axis is paralel
-              to the two. This is the same as case 2 in get_bonded_axes. Compute a
+            * Find edge heavy atom (i.e. heavy atoms bonded to neighbour residue).
+              Compute rotation centre and axes as in get_terminal_axes.
               custom MOI, using heavy atom positions and heavy atom + hydrogen masses.
 
         - If bonded to at least two other residues:
             * Translational axes are principal axes of data_container.
-            * Find edge heavy atoms (i.e. heavy atoms bonded to neighbour residues)
-              and find the shortest chain between them: the backbone. Edge atoms
-              + backbone COM are used to determine residue rotational axes.
-              (see get_residue_custom_axes). If the two edge heavy atoms
-              are bonded to each other (i.e. there is no backbone), x-axis is set
-              along the vector between the edge atom and average position of bonded
-              atoms, y-axis is arbitrary and z-axis is paralel to the two. This is the
-              same as case 2 in get_bonded_axes. Compute a custom MOI, using heavy
-              atom positions and heavy atom + hydrogen masses.
+            * Find edge heavy atoms (i.e. heavy atoms bonded to neighbour residues).
+              Compute rotation centre and axes as in get_non_terminal_axes.
+              Compute a custom MOI, using heavy atom positions and
+              heavy atom + hydrogen masses.
 
         Args:
             data_container (MDAnalysis.Universe or AtomGroup):
@@ -161,54 +149,13 @@ class AxesCalculator:
         else:
             make_whole(data_container.atoms)
             trans_axes = data_container.atoms.principal_axes()
-
             if len(edge_atom_set) == 1:
                 edge_atom = edge_atom_set[0]
-                bonded_atoms = residue.select_atoms(
-                    f"(mass 2 to 999) and bonded index {edge_atom.index}"
-                )
-                # find the average position of heavy atoms bonded to edge atom
-                if len(bonded_atoms) > 0:
-                    average_bonded_atom = np.zeros(3)
-                    for bonded_atom in bonded_atoms:
-                        average_bonded_atom += bonded_atom.position
-                    average_bonded_atom /= len(bonded_atoms)
-                # find the average position of all other heavy atoms in residue
-                other_atoms = []
-                for atom in uas:
-                    if atom != edge_atom and atom not in bonded_atoms:
-                        other_atoms.append(atom)
-                if len(other_atoms) > 0:
-                    average_other_atoms = np.zeros(3)
-                    for atom in other_atoms:
-                        average_other_atoms += atom.position
-                    average_other_atoms /= len(other_atoms)
-                    rot_center, rot_axes = self.get_residue_custom_axes(
-                        [edge_atom.position, average_other_atoms], average_bonded_atom
-                    )
-                else:
-                    rot_center = edge_atom.position
-                    rot_axes = self.get_custom_axes(
-                        a=edge_atom.position, b=[average_bonded_atom], c=np.zeros(3)
-                    )
-
+                rot_center, rot_axes = self.get_terminal_axes(residue, edge_atom)
             else:
-                edges = [edge_atom_set[0].position, edge_atom_set[1].position]
-                backbone = self.get_chain(residue, edge_atom_set[0], edge_atom_set[1])
-                backbone_center = np.zeros(3)
-                if len(backbone) > 0:
-                    for heavy_atom in backbone:
-                        backbone_center += heavy_atom.position
-                    backbone_center /= len(backbone)
-                    rot_center, rot_axes = self.get_residue_custom_axes(
-                        edges, backbone_center
-                    )
-                else:
-                    rot_center = (edges[0] + edges[1]) / 2
-                    rot_axes = self.get_custom_axes(
-                        a=rot_center, b=[edges[0]], c=np.zeros(3)
-                    )
-
+                rot_center, rot_axes = self.get_non_terminal_axes(
+                    residue, edge_atom_set
+                )
             moment_of_inertia = self.get_custom_residue_moment_of_inertia(
                 center_of_mass=rot_center,
                 positions=uas.positions,
@@ -289,26 +236,8 @@ class AxesCalculator:
             - If there are *no* bonds to other residues, use a custom principal axes
             from a moment-of-inertia (MOI) tensor that uses positions of heavy atoms
             only, but includes masses of heavy atom + bonded hydrogens.
-            - If bonded to only one other residue and there are only two heavy atoms
-            in the residue/all heavy atoms are bonded to edge atom,
-            x-axis is set along the vector between the edge atom and average position
-            of bonded atoms, y-axis is arbitrary and z-axis is paralel to the two.
-            This is the same as case 2 in get_bonded_axes.
-            - If bonded to only one other residue, find edge heavy atom
-            (i.e. heavy atom bonded to neighbour residue). Find all heavy atoms
-            bonded to edge heavy atom and compute their average position.
-            Find all other heavy atoms in residue and compute their average position.
-            The three points are now used to obtain determine residue rotational axes.
-            (see get_residue_custom_axes)
-            - If bonded to at least two other residues, find edge heavy atoms
-            (i.e. heavy atoms bonded to neighbour residues) and find the shortest
-            chain between them: the backbone. Edge atoms + backbone COM are used
-            to determine residue rotational axes. (see get_residue_custom_axes).
-            - If bonded to at least two other residues and the two edge heavy atoms
-            are bonded to each other (i.e. there is no backbone), x-axis is set along
-            the vector between the edge atom and average position of bonded atoms,
-            y-axis is arbitrary and z-axis is paralel to the two. This is the same
-            as case 2 in get_bonded_axes.
+            - If bonded to only one other residue, see get_terminal_axes.
+            - If bonded to at least two other residues, see get_non_terminal_axes.
 
         - Rotational axes:
             Identify heavy atoms in the residue/molecule of interest and choose
@@ -346,7 +275,6 @@ class AxesCalculator:
                 residue = data_container
                 trans_center = data_container.atoms.center_of_mass(unwrap=True)
                 trans_axes = data_container.atoms.principal_axes()
-                residue_heavy_atoms = heavy_atoms
             else:
                 # residue of interest has at least one neighbour
                 if res_position == -1 or res_position == 1:
@@ -368,35 +296,9 @@ class AxesCalculator:
                             f"resindex {resindex} and bonded resindex {resindex_prev}"
                         )
                     edge_atom = edge_atom_set[0]
-                    residue_heavy_atoms = residue.atoms.select_atoms("mass 2 to 999")
-                    bonded_atoms = residue.atoms.select_atoms(
-                        f"(mass 2 to 999) and bonded index {edge_atom.index}"
+                    trans_center, trans_axes = self.get_terminal_axes(
+                        residue, edge_atom
                     )
-                    # find the average position of heavy atoms bonded to edge atom
-                    if len(bonded_atoms) > 0:
-                        average_bonded_atom = np.zeros(3)
-                        for atom in bonded_atoms:
-                            average_bonded_atom += atom.position
-                        average_bonded_atom /= len(bonded_atoms)
-                    # find the average position of all other heavy atoms in residue
-                    other_atoms = []
-                    for atom in residue_heavy_atoms:
-                        if atom != edge_atom and atom not in bonded_atoms:
-                            other_atoms.append(atom)
-                    average_other_atoms = np.zeros(3)
-                    if len(other_atoms) > 0:
-                        for atom in other_atoms:
-                            average_other_atoms += atom.position
-                        average_other_atoms /= len(other_atoms)
-                        trans_center, trans_axes = self.get_residue_custom_axes(
-                            [edge_atom.position, average_other_atoms],
-                            average_bonded_atom,
-                        )
-                    else:
-                        trans_center = edge_atom.position
-                        trans_axes = self.get_custom_axes(
-                            a=edge_atom.position, b=[average_bonded_atom], c=np.zeros(3)
-                        )
                 else:
                     # between 2 residues
                     residue = data_container.residues[1]
@@ -404,28 +306,16 @@ class AxesCalculator:
                     resindex_next = resindex + 1
                     resindex_prev = resindex - 1
                     residue_heavy_atoms = residue.atoms.select_atoms("mass 2 to 999")
-                    edge_set = data_container.select_atoms(
+                    edge_atom_set = data_container.select_atoms(
                         f"resindex {resindex} and "
                         f"(bonded resindex {resindex_prev} or "
                         f"resindex {resindex_next})"
                     )
-                    edges = edge_set.positions
-                    backbone = self.get_chain(residue, edge_set[0], edge_set[1])
-                    if len(backbone) > 0:
-                        backbone_center = np.zeros(3)
-                        for heavy_atom in backbone:
-                            backbone_center += heavy_atom.position
-                        backbone_center /= len(backbone)
-                        trans_center, trans_axes = self.get_residue_custom_axes(
-                            edges, backbone_center
-                        )
-                    else:
-                        trans_center = (edges[0] + edges[1]) / 2
-                        trans_axes = self.get_custom_axes(
-                            a=trans_center, b=[edges[0]], c=np.zeros(3)
-                        )
-
+                    trans_center, trans_axes = self.get_non_terminal_axes(
+                        residue, edge_atom_set
+                    )
             # look for heavy atoms in residue of interest
+            residue_heavy_atoms = residue.atoms.select_atoms("mass 2 to 999")
             heavy_atom_indices = []
             for atom in residue_heavy_atoms:
                 heavy_atom_indices.append(atom.index)
@@ -670,6 +560,98 @@ class AxesCalculator:
         z_axis /= np.linalg.norm(z_axis)
         rot_axes = np.array([x_axis, y_axis, z_axis])
         rot_center = first_edge_origin_vector + edges[0]
+        return rot_center, rot_axes
+
+    def get_terminal_axes(self, residue, edge):
+        """
+        Compute rotation axes at the residue level/translation axes at the UA level
+        for the terminal residues in a polymer, given the edge atom
+        (i.e. atom bonded to neighbour residue) and residue of interest.
+        Find all heavy atoms bonded to edge heavy atom and compute
+        their average position. Find all other heavy atoms in residue
+        and compute their average position. The three points are now used to
+        obtain determine residue rotational axes. (see get_residue_custom_axes)
+        If there are only two heavy atoms in the residue/all heavy atoms are bonded
+        to edge atom, x-axis is set along the vector between the
+        edge atom and average position of bonded atoms, y-axis is arbitrary
+        and z-axis is paralel to the two. This is the same as case 2 in get_bonded_axes.
+        If there no heavy atoms bonded to the edge atom (i.e. the edge atom is the only
+        heavy atom in the residue), centre is set on edge atom and axes are principal
+        axes.
+
+        Args:
+            residue: MDAnalysis AtomGroup
+            edge: MDAnalysis atom
+
+        Returns:
+            rot_center: (3,) rotation centre,
+            rot_axes: (3,3) rotation axes of residue
+        """
+        heavy_atoms = residue.atoms.select_atoms("mass 2 to 999")
+        bonded_atoms = residue.atoms.select_atoms(
+            f"(mass 2 to 999) and bonded index {edge.index}"
+        )
+        if len(bonded_atoms) == 0:
+            # there is only one heavy atom in the residue
+            rot_center = edge.position
+            rot_axes = residue.atoms.principal_axes()
+        else:
+            average_bonded = np.zeros(3)
+            for bonded_atom in bonded_atoms:
+                average_bonded += bonded_atom.position
+            average_bonded /= len(bonded_atoms)
+            # find the average position of all other heavy atoms in residue
+            other_atoms = []
+            for atom in heavy_atoms:
+                if atom != edge and atom not in bonded_atoms:
+                    other_atoms.append(atom)
+            if len(other_atoms) > 0:
+                average_other_atoms = np.zeros(3)
+                for atom in other_atoms:
+                    average_other_atoms += atom.position
+                average_other_atoms /= len(other_atoms)
+                rot_center, rot_axes = self.get_residue_custom_axes(
+                    [edge.position, average_other_atoms], average_bonded
+                )
+            else:
+                rot_center = edge.position
+                rot_axes = self.get_custom_axes(
+                    a=edge.position, b=[average_bonded], c=np.zeros(3)
+                )
+        return rot_center, rot_axes
+
+    def get_non_terminal_axes(self, residue, edges):
+        """
+        Compute rotation axes at the residue level/ translation axes at
+        the UA level for the non-terminal residues in a linear polymer, given the
+        edge atoms (i.e. heavy atoms bonded to neighbour residues) and
+        residue of interest. Find the shortest chain between edge atoms: the backbone.
+        Edges + backbone average position determine the residue rotational axes.
+        (see get_residue_custom_axes). If the two edge heavy atoms
+        are bonded to each other (i.e. there is no backbone), x-axis is set
+        along the vector between the edge atom and average position of bonded
+        atoms, y-axis is arbitrary and z-axis is paralel to the two. This is the
+        same as case 2 in get_bonded_axes.
+        Args:
+            residue: MDAnalysis AtomGroup
+            edges: MDAnalysis AtomGroup
+
+        Returns:
+            rot_center: (3,) rotation centre,
+            rot_axes: (3,3) rotation axes of residue
+        """
+        backbone = self.get_chain(residue, edges[0], edges[1])
+        backbone_center = np.zeros(3)
+        if len(backbone) > 0:
+            for heavy_atom in backbone:
+                backbone_center += heavy_atom.position
+            backbone_center /= len(backbone)
+            rot_center, rot_axes = self.get_residue_custom_axes(
+                edges.positions, backbone_center
+            )
+        else:
+            rot_center = (edges[0].position + edges[1].position) / 2
+            rot_axes = self.get_custom_axes(a=rot_center, b=[edges[0]], c=np.zeros(3))
         return rot_center, rot_axes
 
     def get_bonded_axes(self, system, atom, dimensions: np.ndarray):

--- a/CodeEntropy/levels/axes.py
+++ b/CodeEntropy/levels/axes.py
@@ -77,23 +77,23 @@ class AxesCalculator:
               heavy atom + bonded hydrogens.
             * Set translational axes equal to rotational axes (as per the original
               code convention).
+
         - If bonded to only one other residue:
             * Translational axes are principal axes of data_container.
             * Find edge heavy atom (i.e. heavy atoms bonded to neighbour residue).
             Find all heavy atoms bonded to edge heavy atom and compute their average
             position. Find all other heavy atoms in residue and compute their average
             position.The three points are now used to obtain determine residue
-            rotational axes. (see get_residue_custom_axes)
-            Compute a custom MOI, using heavy atom positions and
-          heavy atom + hydrogen masses.
+            rotational axes. (see get_residue_custom_axes) Compute a custom MOI,
+            using heavy atom positions and heavy atom + hydrogen masses.
+
         - If bonded to at least two other residues:
             * Translational axes are principal axes of data_container.
             * Find edge heavy atoms (i.e. heavy atoms bonded to neighbour residues)
             and find the shortest chain between them: the backbone. Edge
             atoms + backbone COM are used to determine residue rotational axes.
-            (see get_residue_custom_axes).
-            Compute a custom MOI, using heavy atom positions and
-          heavy atom + hydrogen masses.
+            (see get_residue_custom_axes). Compute a custom MOI, using heavy
+            atom positions and heavy atom + hydrogen masses.
 
         Args:
             data_container (MDAnalysis.Universe or AtomGroup):

--- a/CodeEntropy/levels/axes.py
+++ b/CodeEntropy/levels/axes.py
@@ -280,8 +280,7 @@ class AxesCalculator:
             Identify heavy atoms in the residue/molecule of interest and choose
             the `index`-th heavy atom (where index corresponds to the bead index).
             Use bonded topology around that heavy atom to determine UA rotational
-            axes (see :meth:`get_bonded_axes`).
-            Compute a custom MOI tensor.
+            axes (see :meth:`get_bonded_axes`). Compute a custom MOI tensor.
 
         Args:
             data_container (MDAnalysis.Universe or AtomGroup):

--- a/CodeEntropy/levels/axes.py
+++ b/CodeEntropy/levels/axes.py
@@ -77,7 +77,10 @@ class AxesCalculator:
               heavy atom + bonded hydrogens.
             * Set translational axes equal to rotational axes (as per the original
               code convention).
-        - If bonded to other residues:
+        - If bonded to only one other residue:
+            * Translational axes are principal axes of data_container.
+            * Find edge heavy atom (i.e. heavy atoms bonded to neighbour residue).
+        - If bonded to at least two other residues:
             * Translational axes are principal axes of data_container.
             * Find edge heavy atoms (i.e. heavy atoms bonded to neighbour residues)
               and find the shortest chain between them: the backbone. Edge
@@ -145,30 +148,36 @@ class AxesCalculator:
             trans_axes = data_container.atoms.principal_axes()
 
             if len(edge_atom_set) == 1:
-                if index == 0:
-                    # first residue: use first heavy atom
-                    edges = [residue.atoms[0], edge_atom_set[0]]
-                    backbone = self.get_chain(
-                        residue, residue.atoms[0], edge_atom_set[0]
-                    )
-                else:
-                    # last residue: last heavy atom
-                    last_index = len(uas) - 1
-                    last = None
-                    if last_index > 0 and last is None:
-                        heavy_atom = uas[last_index]
-                        last = heavy_atom
-                    edges = [edge_atom_set[0], last]
+                edge_atom = edge_atom_set[0]
+                bonded_atoms = uas.select_atoms(f"bonded index {edge_atom.index}")
+                # find the average position of heavy atoms bonded to edge atom
+                average_bonded_atom = np.zeros(3)
+                for atom in bonded_atoms:
+                    average_bonded_atom += atom.position
+                average_bonded_atom /= len(bonded_atoms)
+                # find the average position of all other heavy atoms in residue
+                other_atoms = []
+                for atom in uas:
+                    if atom != edge_atom and atom not in bonded_atoms:
+                        other_atoms.append(atom)
+                average_other_atoms = np.zeros(3)
+                for atom in other_atoms:
+                    average_other_atoms += atom.position
+                average_other_atoms /= len(other_atoms)
+                rot_center, rot_axes = self.get_residue_custom_axes(
+                    [edge_atom.position, average_other_atoms], average_bonded_atom
+                )
 
-                    backbone = self.get_chain(residue, edge_atom_set[0], last)
             else:
-                edges = [edge_atom_set[0], edge_atom_set[1]]
+                edges = [edge_atom_set[0].position, edge_atom_set[1].position]
                 backbone = self.get_chain(residue, edge_atom_set[0], edge_atom_set[1])
-            backbone_center = np.zeros(3)
-            for heavy_atom in backbone:
-                backbone_center += heavy_atom.position
-            backbone_center = backbone_center / len(backbone)
-            rot_center, rot_axes = self.get_residue_custom_axes(edges, backbone_center)
+                backbone_center = np.zeros(3)
+                for heavy_atom in backbone:
+                    backbone_center += heavy_atom.position
+                backbone_center = backbone_center / len(backbone)
+                rot_center, rot_axes = self.get_residue_custom_axes(
+                    edges, backbone_center
+                )
 
             moment_of_inertia = self.get_custom_residue_moment_of_inertia(
                 center_of_mass=rot_center,
@@ -248,7 +257,8 @@ class AxesCalculator:
             Identify residue of interest and neighbours, then select
             edge heavy atoms (i.e. heavy atoms bonded to neighbour residues).
             If there are no bonds to neighbouring residues, use residue
-            .principal axes Otherwise, find the shortest chain between edge
+            principal axes. Otherwise, for residues with at least two neighbours,
+            find the shortest chain between edge
             residues: the backbone. Edge atoms + backbone COM are used to
             determine UA translational axes (see get_residue_custom_axes)
 
@@ -293,66 +303,69 @@ class AxesCalculator:
                 residue_heavy_atoms = heavy_atoms
             else:
                 # residue of interest has at least one neighbour
-                if res_position == -1:
-                    residue = data_container.residues[0]
-                    resindex = residue.resindex
-                    resindex_next = resindex + 1
-
-                    second_edge = data_container.select_atoms(
-                        f"resindex {resindex} and bonded resindex {resindex_next}"
+                if res_position == -1 or res_position == 1:
+                    # look at a terminal residue
+                    if res_position == -1:
+                        # first residue
+                        residue = data_container.residues[0]
+                        resindex = residue.resindex
+                        resindex_next = resindex + 1
+                        edge_atom = data_container.select_atoms(
+                            f"resindex {resindex} and bonded resindex {resindex_next}"
+                        )
+                    else:
+                        # last residue
+                        residue = data_container.residues[1]
+                        resindex = residue.resindex
+                        resindex_prev = resindex - 1
+                        edge_atom = data_container.select_atoms(
+                            f"resindex {resindex} and bonded resindex {resindex_prev}"
+                        )
+                    residue_heavy_atoms = residue.atoms.select_atoms("mass 2 to 999")
+                    bonded_atoms = residue_heavy_atoms.select_atoms(
+                        f"bonded index {edge_atom[0].index}"
                     )
-
-                    edges = [residue.atoms[0], second_edge[0]]
-                    backbone = self.get_chain(
-                        residue, residue.atoms[0], second_edge.atoms[0]
+                    # find the average position of heavy atoms bonded to edge atom
+                    average_bonded_atom = np.zeros(3)
+                    for atom in bonded_atoms:
+                        average_bonded_atom += atom.position
+                    average_bonded_atom /= len(bonded_atoms)
+                    # find the average position of all other heavy atoms in residue
+                    other_atoms = []
+                    for atom in residue_heavy_atoms:
+                        if atom != edge_atom and atom not in bonded_atoms:
+                            other_atoms.append(atom)
+                    average_other_atoms = np.zeros(3)
+                    for atom in other_atoms:
+                        average_other_atoms += atom.position
+                    average_other_atoms /= len(other_atoms)
+                    trans_center, trans_axes = self.get_residue_custom_axes(
+                        [edge_atom.positions[0], average_other_atoms],
+                        average_bonded_atom,
                     )
-
-                elif res_position == 0:
+                else:
                     # between 2 residues
                     residue = data_container.residues[1]
                     resindex = residue.resindex
                     resindex_next = resindex + 1
                     resindex_prev = resindex - 1
-
+                    residue_heavy_atoms = residue.atoms.select_atoms("mass 2 to 999")
                     edge_set = data_container.select_atoms(
                         f"resindex {resindex} and "
                         f"(bonded resindex {resindex_prev} or "
                         f"resindex {resindex_next})"
                     )
 
-                    edges = [edge_set[0], edge_set[1]]
+                    edges = edge_set.positions
                     backbone = self.get_chain(residue, edge_set[0], edge_set[1])
+                    backbone_center = np.zeros(3)
+                    for heavy_atom in backbone:
+                        backbone_center += heavy_atom.position
+                    backbone_center = backbone_center / len(backbone)
 
-                else:
-                    # last resid
-                    # always resindex 1 in data_container
-                    residue = data_container.residues[1]
-                    resindex = residue.resindex
-                    resindex_prev = resindex - 1
-                    first_edge = data_container.select_atoms(
-                        f"resindex {resindex} and bonded resindex {resindex_prev}"
+                    trans_center, trans_axes = self.get_residue_custom_axes(
+                        edges, backbone_center
                     )
-
-                    last_index = len(heavy_atoms) - 1
-                    last = None
-                    # look for last heavy atom
-                    # with only one bond to another
-                    if last_index > 0 and last is None:
-                        heavy_atom = heavy_atoms[last_index]
-                        last = heavy_atom
-
-                    edges = [first_edge.atoms[0], last]
-                    backbone = self.get_chain(residue, first_edge.atoms[0], last)
-
-                backbone_center = np.zeros(3)
-                for heavy_atom in backbone:
-                    backbone_center += heavy_atom.position
-                backbone_center = backbone_center / len(backbone)
-
-                trans_center, trans_axes = self.get_residue_custom_axes(
-                    edges, backbone_center
-                )
-                residue_heavy_atoms = residue.atoms.select_atoms("mass 2 to 999")
 
             # look for heavy atoms in residue of interest
             heavy_atom_indices = []
@@ -580,9 +593,9 @@ class AxesCalculator:
             lies on the E1-E2 vector
             rot_axes: (3,3) rotation axes of residue
         """
-        first_edge_centre_of_geometry_vector = center - edges[0].position
+        first_edge_centre_of_geometry_vector = center - edges[0]
         # look for projection of E1-O onto E1-E2 (E1-C)
-        first_edge_second_edge_vector = edges[1].position - edges[0].position
+        first_edge_second_edge_vector = edges[1] - edges[0]
         first_edge_origin_vector = (
             np.dot(first_edge_second_edge_vector, first_edge_centre_of_geometry_vector)
             / (np.linalg.norm(first_edge_second_edge_vector) ** 2)
@@ -598,7 +611,7 @@ class AxesCalculator:
         y_axis /= np.linalg.norm(y_axis)
         z_axis /= np.linalg.norm(z_axis)
         rot_axes = np.array([x_axis, y_axis, z_axis])
-        rot_center = first_edge_origin_vector + edges[0].position
+        rot_center = first_edge_origin_vector + edges[0]
         return rot_center, rot_axes
 
     def get_bonded_axes(self, system, atom, dimensions: np.ndarray):

--- a/CodeEntropy/levels/axes.py
+++ b/CodeEntropy/levels/axes.py
@@ -187,7 +187,8 @@ class AxesCalculator:
                         [edge_atom.position, average_other_atoms], average_bonded_atom
                     )
                 else:
-                    rot_center, rot_axes = self.get_custom_axes(
+                    rot_center = edge_atom.position
+                    rot_axes = self.get_custom_axes(
                         a=edge_atom.position, b=[average_bonded_atom], c=np.zeros(3)
                     )
 
@@ -203,8 +204,9 @@ class AxesCalculator:
                         edges, backbone_center
                     )
                 else:
-                    rot_center, rot_axes = self.get_custom_axes(
-                        a=edges[0], b=[edges[1]], c=np.zeros(3)
+                    rot_center = (edges[0] + edges[1]) / 2
+                    rot_axes = self.get_custom_axes(
+                        a=rot_center, b=[edges[1]], c=np.zeros(3)
                     )
 
             moment_of_inertia = self.get_custom_residue_moment_of_inertia(
@@ -391,7 +393,8 @@ class AxesCalculator:
                             average_bonded_atom,
                         )
                     else:
-                        trans_center, trans_axes = self.get_custom_axes(
+                        trans_center = edge_atom.position
+                        trans_axes = self.get_custom_axes(
                             a=edge_atom.position, b=[average_bonded_atom], c=np.zeros(3)
                         )
                 else:
@@ -417,8 +420,9 @@ class AxesCalculator:
                             edges, backbone_center
                         )
                     else:
-                        trans_center, trans_axes = self.get_custom_axes(
-                            a=edges[0], b=[edges[1]], c=np.zeros(3)
+                        trans_center = (edges[0] + edges[1]) / 2
+                        trans_axes = self.get_custom_axes(
+                            a=trans_center, b=[edges[1]], c=np.zeros(3)
                         )
 
             # look for heavy atoms in residue of interest

--- a/CodeEntropy/levels/axes.py
+++ b/CodeEntropy/levels/axes.py
@@ -156,21 +156,26 @@ class AxesCalculator:
 
             if len(edge_atom_set) == 1:
                 edge_atom = edge_atom_set[0]
-                bonded_atoms = uas.select_atoms(f"bonded index {edge_atom.index}")
+                bonded_atoms = residue.select_atoms(
+                    f"(mass 2 to 999) and bonded index {edge_atom.index}"
+                )
                 # find the average position of heavy atoms bonded to edge atom
-                average_bonded_atom = np.zeros(3)
-                for atom in bonded_atoms:
-                    average_bonded_atom += atom.position
-                average_bonded_atom /= len(bonded_atoms)
+                if len(bonded_atoms) > 0:
+                    average_bonded_atom = np.zeros(3)
+                    for bonded_atom in bonded_atoms:
+                        average_bonded_atom += bonded_atom.position
+                    average_bonded_atom /= len(bonded_atoms)
                 # find the average position of all other heavy atoms in residue
                 other_atoms = []
                 for atom in uas:
                     if atom != edge_atom and atom not in bonded_atoms:
                         other_atoms.append(atom)
-                average_other_atoms = np.zeros(3)
-                for atom in other_atoms:
-                    average_other_atoms += atom.position
-                average_other_atoms /= len(other_atoms)
+                if len(other_atoms) > 0:
+                    average_other_atoms = np.zeros(3)
+                    for atom in other_atoms:
+                        average_other_atoms += atom.position
+                    average_other_atoms /= len(average_other_atoms)
+
                 rot_center, rot_axes = self.get_residue_custom_axes(
                     [edge_atom.position, average_other_atoms], average_bonded_atom
                 )
@@ -179,9 +184,10 @@ class AxesCalculator:
                 edges = [edge_atom_set[0].position, edge_atom_set[1].position]
                 backbone = self.get_chain(residue, edge_atom_set[0], edge_atom_set[1])
                 backbone_center = np.zeros(3)
-                for heavy_atom in backbone:
-                    backbone_center += heavy_atom.position
-                backbone_center = backbone_center / len(backbone)
+                if len(backbone) > 0:
+                    for heavy_atom in backbone:
+                        backbone_center += heavy_atom.position
+                    backbone_center /= len(backbone)
                 rot_center, rot_axes = self.get_residue_custom_axes(
                     edges, backbone_center
                 )
@@ -323,7 +329,7 @@ class AxesCalculator:
                         residue = data_container.residues[0]
                         resindex = residue.resindex
                         resindex_next = resindex + 1
-                        edge_atom = data_container.select_atoms(
+                        edge_atom_set = data_container.select_atoms(
                             f"resindex {resindex} and bonded resindex {resindex_next}"
                         )
                     else:
@@ -331,29 +337,32 @@ class AxesCalculator:
                         residue = data_container.residues[1]
                         resindex = residue.resindex
                         resindex_prev = resindex - 1
-                        edge_atom = data_container.select_atoms(
+                        edge_atom_set = data_container.select_atoms(
                             f"resindex {resindex} and bonded resindex {resindex_prev}"
                         )
+                    edge_atom = edge_atom_set[0]
                     residue_heavy_atoms = residue.atoms.select_atoms("mass 2 to 999")
-                    bonded_atoms = residue_heavy_atoms.select_atoms(
-                        f"bonded index {edge_atom[0].index}"
+                    bonded_atoms = residue.atoms.select_atoms(
+                        f"(mass 2 to 999) and bonded index {edge_atom.index}"
                     )
                     # find the average position of heavy atoms bonded to edge atom
-                    average_bonded_atom = np.zeros(3)
-                    for atom in bonded_atoms:
-                        average_bonded_atom += atom.position
-                    average_bonded_atom /= len(bonded_atoms)
+                    if len(bonded_atoms) > 0:
+                        average_bonded_atom = np.zeros(3)
+                        for atom in bonded_atoms:
+                            average_bonded_atom += atom.position
+                        average_bonded_atom /= len(bonded_atoms)
                     # find the average position of all other heavy atoms in residue
                     other_atoms = []
                     for atom in residue_heavy_atoms:
                         if atom != edge_atom and atom not in bonded_atoms:
                             other_atoms.append(atom)
                     average_other_atoms = np.zeros(3)
-                    for atom in other_atoms:
-                        average_other_atoms += atom.position
-                    average_other_atoms /= len(other_atoms)
+                    if len(other_atoms) > 0:
+                        for atom in other_atoms:
+                            average_other_atoms += atom.position
+                        average_other_atoms /= len(other_atoms)
                     trans_center, trans_axes = self.get_residue_custom_axes(
-                        [edge_atom.positions[0], average_other_atoms],
+                        [edge_atom.position, average_other_atoms],
                         average_bonded_atom,
                     )
                 else:
@@ -371,10 +380,11 @@ class AxesCalculator:
 
                     edges = edge_set.positions
                     backbone = self.get_chain(residue, edge_set[0], edge_set[1])
-                    backbone_center = np.zeros(3)
-                    for heavy_atom in backbone:
-                        backbone_center += heavy_atom.position
-                    backbone_center = backbone_center / len(backbone)
+                    if len(backbone) > 0:
+                        backbone_center = np.zeros(3)
+                        for heavy_atom in backbone:
+                            backbone_center += heavy_atom.position
+                        backbone_center /= len(backbone)
 
                     trans_center, trans_axes = self.get_residue_custom_axes(
                         edges, backbone_center

--- a/CodeEntropy/levels/axes.py
+++ b/CodeEntropy/levels/axes.py
@@ -73,20 +73,26 @@ class AxesCalculator:
           (previous/next in sequence) using MDAnalysis bonded selections.
         - If there are *no* bonds to other residues:
             * Use a custom principal axes, from a moment-of-inertia (MOI) tensor
-              that uses positions of heavy atoms only, but including masses of
+              that uses positions of heavy atoms only, but includes masses of
               heavy atom + bonded hydrogens.
             * Set translational axes equal to rotational axes (as per the original
               code convention).
         - If bonded to only one other residue:
             * Translational axes are principal axes of data_container.
             * Find edge heavy atom (i.e. heavy atoms bonded to neighbour residue).
+              Find all heavy atoms bonded to edge heavy atom and compute their average
+              position.
+              Find all other heavy atoms in residue and compute their average position.
+              The three points are now used to obtain determine residue rotational axes.
+              (see get_residue_custom_axes)
         - If bonded to at least two other residues:
             * Translational axes are principal axes of data_container.
             * Find edge heavy atoms (i.e. heavy atoms bonded to neighbour residues)
               and find the shortest chain between them: the backbone. Edge
               atoms + backbone COM are used to determine residue rotational axes.
-              (see get_residue_custom_axes).Compute a custom MOI, using heavy atom
-              positions and heavy atom + hydrogen masses.
+              (see get_residue_custom_axes).
+        Compute a custom MOI, using heavy atom positions and
+          heavy atom + hydrogen masses.
 
         Args:
             data_container (MDAnalysis.Universe or AtomGroup):
@@ -256,19 +262,25 @@ class AxesCalculator:
             Use the same approach as residue level rotational.
             Identify residue of interest and neighbours, then select
             edge heavy atoms (i.e. heavy atoms bonded to neighbour residues).
-            If there are no bonds to neighbouring residues, use residue
-            principal axes. Otherwise, for residues with at least two neighbours,
-            find the shortest chain between edge
-            residues: the backbone. Edge atoms + backbone COM are used to
-            determine UA translational axes (see get_residue_custom_axes)
-
+            - If there are *no* bonds to other residues, use a custom principal axes
+              from a moment-of-inertia (MOI) tensor that uses positions of heavy atoms
+              only, but includes masses of heavy atom + bonded hydrogens.
+            - If bonded to only one other residue, find edge heavy atom
+              (i.e. heavy atom bonded to neighbour residue). Find all heavy atoms
+              bonded to edge heavy atom and compute their average position.
+              Find all other heavy atoms in residue and compute their average position.
+              The three points are now used to obtain determine residue rotational axes.
+              (see get_residue_custom_axes)
+            - If bonded to at least two other residues, find edge heavy atoms
+            (i.e. heavy atoms bonded to neighbour residues) and find the shortest
+              chain between them: the backbone. Edge atoms + backbone COM are used
+              to determine residue rotational axes. (see get_residue_custom_axes).
         - Rotational axes:
             Identify heavy atoms in the residue/molecule of interest and choose
             the `index`-th heavy atom (where index corresponds to the bead index).
             Use bonded topology around that heavy atom to determine UA rotational
             axes (see :meth:`get_bonded_axes`).
-            Compute a custom MOI tensor using heavy-atom coordinates but UA masses
-            (heavy + bonded H masses), then compute the principal axes from it.
+            Compute a custom MOI tensor.
 
         Args:
             data_container (MDAnalysis.Universe or AtomGroup):

--- a/CodeEntropy/levels/axes.py
+++ b/CodeEntropy/levels/axes.py
@@ -84,15 +84,23 @@ class AxesCalculator:
               all heavy atoms bonded to edge heavy atom and compute their average
               position. Find all other heavy atoms in residue and compute their average
               position.The three points are now used to obtain determine residue
-              rotational axes. (see get_residue_custom_axes) Compute a custom MOI,
-              using heavy atom positions and heavy atom + hydrogen masses.
+              rotational axes. (see get_residue_custom_axes) If there are
+              only two heavy atoms in the residue/all heavy atoms are bonded to edge
+              atom, x-axis is set along the vector between the edge atom and average
+              position of bonded atoms, y-axis is arbitrary and z-axis is paralel
+              to the two. This is the same as case 2 in get_bonded_axes. Compute a
+              custom MOI, using heavy atom positions and heavy atom + hydrogen masses.
 
         - If bonded to at least two other residues:
             * Translational axes are principal axes of data_container.
             * Find edge heavy atoms (i.e. heavy atoms bonded to neighbour residues)
               and find the shortest chain between them: the backbone. Edge atoms
               + backbone COM are used to determine residue rotational axes.
-              (see get_residue_custom_axes). Compute a custom MOI, using heavy
+              (see get_residue_custom_axes). If the two edge heavy atoms
+              are bonded to each other (i.e. there is no backbone), x-axis is set
+              along the vector between the edge atom and average position of bonded
+              atoms, y-axis is arbitrary and z-axis is paralel to the two. This is the
+              same as case 2 in get_bonded_axes. Compute a custom MOI, using heavy
               atom positions and heavy atom + hydrogen masses.
 
         Args:
@@ -175,10 +183,13 @@ class AxesCalculator:
                     for atom in other_atoms:
                         average_other_atoms += atom.position
                     average_other_atoms /= len(average_other_atoms)
-
-                rot_center, rot_axes = self.get_residue_custom_axes(
-                    [edge_atom.position, average_other_atoms], average_bonded_atom
-                )
+                    rot_center, rot_axes = self.get_residue_custom_axes(
+                        [edge_atom.position, average_other_atoms], average_bonded_atom
+                    )
+                else:
+                    rot_center, rot_axes = self.get_custom_axes(
+                        a=edge_atom.position, b=[average_bonded_atom], c=np.zeros(3)
+                    )
 
             else:
                 edges = [edge_atom_set[0].position, edge_atom_set[1].position]
@@ -188,9 +199,13 @@ class AxesCalculator:
                     for heavy_atom in backbone:
                         backbone_center += heavy_atom.position
                     backbone_center /= len(backbone)
-                rot_center, rot_axes = self.get_residue_custom_axes(
-                    edges, backbone_center
-                )
+                    rot_center, rot_axes = self.get_residue_custom_axes(
+                        edges, backbone_center
+                    )
+                else:
+                    rot_center, rot_axes = self.get_custom_axes(
+                        a=edges[0], b=[edges[1]], c=np.zeros(3)
+                    )
 
             moment_of_inertia = self.get_custom_residue_moment_of_inertia(
                 center_of_mass=rot_center,
@@ -272,6 +287,11 @@ class AxesCalculator:
             - If there are *no* bonds to other residues, use a custom principal axes
             from a moment-of-inertia (MOI) tensor that uses positions of heavy atoms
             only, but includes masses of heavy atom + bonded hydrogens.
+            - If bonded to only one other residue and there are only two heavy atoms
+            in the residue/all heavy atoms are bonded to edge atom,
+            x-axis is set along the vector between the edge atom and average position
+            of bonded atoms, y-axis is arbitrary and z-axis is paralel to the two.
+            This is the same as case 2 in get_bonded_axes.
             - If bonded to only one other residue, find edge heavy atom
             (i.e. heavy atom bonded to neighbour residue). Find all heavy atoms
             bonded to edge heavy atom and compute their average position.
@@ -282,6 +302,11 @@ class AxesCalculator:
             (i.e. heavy atoms bonded to neighbour residues) and find the shortest
             chain between them: the backbone. Edge atoms + backbone COM are used
             to determine residue rotational axes. (see get_residue_custom_axes).
+            - If bonded to at least two other residues and the two edge heavy atoms
+            are bonded to each other (i.e. there is no backbone), x-axis is set along
+            the vector between the edge atom and average position of bonded atoms,
+            y-axis is arbitrary and z-axis is paralel to the two. This is the same
+            as case 2 in get_bonded_axes.
 
         - Rotational axes:
             Identify heavy atoms in the residue/molecule of interest and choose
@@ -361,10 +386,14 @@ class AxesCalculator:
                         for atom in other_atoms:
                             average_other_atoms += atom.position
                         average_other_atoms /= len(other_atoms)
-                    trans_center, trans_axes = self.get_residue_custom_axes(
-                        [edge_atom.position, average_other_atoms],
-                        average_bonded_atom,
-                    )
+                        trans_center, trans_axes = self.get_residue_custom_axes(
+                            [edge_atom.position, average_other_atoms],
+                            average_bonded_atom,
+                        )
+                    else:
+                        trans_center, trans_axes = self.get_custom_axes(
+                            a=edge_atom.position, b=[average_bonded_atom], c=np.zeros(3)
+                        )
                 else:
                     # between 2 residues
                     residue = data_container.residues[1]
@@ -377,7 +406,6 @@ class AxesCalculator:
                         f"(bonded resindex {resindex_prev} or "
                         f"resindex {resindex_next})"
                     )
-
                     edges = edge_set.positions
                     backbone = self.get_chain(residue, edge_set[0], edge_set[1])
                     if len(backbone) > 0:
@@ -385,10 +413,13 @@ class AxesCalculator:
                         for heavy_atom in backbone:
                             backbone_center += heavy_atom.position
                         backbone_center /= len(backbone)
-
-                    trans_center, trans_axes = self.get_residue_custom_axes(
-                        edges, backbone_center
-                    )
+                        trans_center, trans_axes = self.get_residue_custom_axes(
+                            edges, backbone_center
+                        )
+                    else:
+                        trans_center, trans_axes = self.get_custom_axes(
+                            a=edges[0], b=[edges[1]], c=np.zeros(3)
+                        )
 
             # look for heavy atoms in residue of interest
             heavy_atom_indices = []

--- a/CodeEntropy/levels/axes.py
+++ b/CodeEntropy/levels/axes.py
@@ -265,16 +265,19 @@ class AxesCalculator:
             - If there are *no* bonds to other residues, use a custom principal axes
             from a moment-of-inertia (MOI) tensor that uses positions of heavy atoms
             only, but includes masses of heavy atom + bonded hydrogens.
+
             - If bonded to only one other residue, find edge heavy atom
             (i.e. heavy atom bonded to neighbour residue). Find all heavy atoms
             bonded to edge heavy atom and compute their average position.
             Find all other heavy atoms in residue and compute their average position.
-             The three points are now used to obtain determine residue rotational axes.
+            The three points are now used to obtain determine residue rotational axes.
             (see get_residue_custom_axes)
+
             - If bonded to at least two other residues, find edge heavy atoms
             (i.e. heavy atoms bonded to neighbour residues) and find the shortest
             chain between them: the backbone. Edge atoms + backbone COM are used
             to determine residue rotational axes. (see get_residue_custom_axes).
+
         - Rotational axes:
             Identify heavy atoms in the residue/molecule of interest and choose
             the `index`-th heavy atom (where index corresponds to the bead index).

--- a/CodeEntropy/levels/axes.py
+++ b/CodeEntropy/levels/axes.py
@@ -265,14 +265,12 @@ class AxesCalculator:
             - If there are *no* bonds to other residues, use a custom principal axes
             from a moment-of-inertia (MOI) tensor that uses positions of heavy atoms
             only, but includes masses of heavy atom + bonded hydrogens.
-
             - If bonded to only one other residue, find edge heavy atom
             (i.e. heavy atom bonded to neighbour residue). Find all heavy atoms
             bonded to edge heavy atom and compute their average position.
             Find all other heavy atoms in residue and compute their average position.
             The three points are now used to obtain determine residue rotational axes.
             (see get_residue_custom_axes)
-
             - If bonded to at least two other residues, find edge heavy atoms
             (i.e. heavy atoms bonded to neighbour residues) and find the shortest
             chain between them: the backbone. Edge atoms + backbone COM are used

--- a/CodeEntropy/levels/axes.py
+++ b/CodeEntropy/levels/axes.py
@@ -80,18 +80,19 @@ class AxesCalculator:
         - If bonded to only one other residue:
             * Translational axes are principal axes of data_container.
             * Find edge heavy atom (i.e. heavy atoms bonded to neighbour residue).
-              Find all heavy atoms bonded to edge heavy atom and compute their average
-              position.
-              Find all other heavy atoms in residue and compute their average position.
-              The three points are now used to obtain determine residue rotational axes.
-              (see get_residue_custom_axes)
+            Find all heavy atoms bonded to edge heavy atom and compute their average
+            position. Find all other heavy atoms in residue and compute their average
+            position.The three points are now used to obtain determine residue
+            rotational axes. (see get_residue_custom_axes)
+            Compute a custom MOI, using heavy atom positions and
+          heavy atom + hydrogen masses.
         - If bonded to at least two other residues:
             * Translational axes are principal axes of data_container.
             * Find edge heavy atoms (i.e. heavy atoms bonded to neighbour residues)
-              and find the shortest chain between them: the backbone. Edge
-              atoms + backbone COM are used to determine residue rotational axes.
-              (see get_residue_custom_axes).
-        Compute a custom MOI, using heavy atom positions and
+            and find the shortest chain between them: the backbone. Edge
+            atoms + backbone COM are used to determine residue rotational axes.
+            (see get_residue_custom_axes).
+            Compute a custom MOI, using heavy atom positions and
           heavy atom + hydrogen masses.
 
         Args:

--- a/CodeEntropy/levels/axes.py
+++ b/CodeEntropy/levels/axes.py
@@ -182,7 +182,7 @@ class AxesCalculator:
                     average_other_atoms = np.zeros(3)
                     for atom in other_atoms:
                         average_other_atoms += atom.position
-                    average_other_atoms /= len(average_other_atoms)
+                    average_other_atoms /= len(other_atoms)
                     rot_center, rot_axes = self.get_residue_custom_axes(
                         [edge_atom.position, average_other_atoms], average_bonded_atom
                     )

--- a/CodeEntropy/levels/axes.py
+++ b/CodeEntropy/levels/axes.py
@@ -263,18 +263,18 @@ class AxesCalculator:
             Identify residue of interest and neighbours, then select
             edge heavy atoms (i.e. heavy atoms bonded to neighbour residues).
             - If there are *no* bonds to other residues, use a custom principal axes
-              from a moment-of-inertia (MOI) tensor that uses positions of heavy atoms
-              only, but includes masses of heavy atom + bonded hydrogens.
+            from a moment-of-inertia (MOI) tensor that uses positions of heavy atoms
+            only, but includes masses of heavy atom + bonded hydrogens.
             - If bonded to only one other residue, find edge heavy atom
-              (i.e. heavy atom bonded to neighbour residue). Find all heavy atoms
-              bonded to edge heavy atom and compute their average position.
-              Find all other heavy atoms in residue and compute their average position.
-              The three points are now used to obtain determine residue rotational axes.
-              (see get_residue_custom_axes)
+            (i.e. heavy atom bonded to neighbour residue). Find all heavy atoms
+            bonded to edge heavy atom and compute their average position.
+            Find all other heavy atoms in residue and compute their average position.
+             The three points are now used to obtain determine residue rotational axes.
+            (see get_residue_custom_axes)
             - If bonded to at least two other residues, find edge heavy atoms
             (i.e. heavy atoms bonded to neighbour residues) and find the shortest
-              chain between them: the backbone. Edge atoms + backbone COM are used
-              to determine residue rotational axes. (see get_residue_custom_axes).
+            chain between them: the backbone. Edge atoms + backbone COM are used
+            to determine residue rotational axes. (see get_residue_custom_axes).
         - Rotational axes:
             Identify heavy atoms in the residue/molecule of interest and choose
             the `index`-th heavy atom (where index corresponds to the bead index).

--- a/CodeEntropy/levels/axes.py
+++ b/CodeEntropy/levels/axes.py
@@ -206,7 +206,7 @@ class AxesCalculator:
                 else:
                     rot_center = (edges[0] + edges[1]) / 2
                     rot_axes = self.get_custom_axes(
-                        a=rot_center, b=[edges[1]], c=np.zeros(3)
+                        a=rot_center, b=[edges[0]], c=np.zeros(3)
                     )
 
             moment_of_inertia = self.get_custom_residue_moment_of_inertia(
@@ -422,7 +422,7 @@ class AxesCalculator:
                     else:
                         trans_center = (edges[0] + edges[1]) / 2
                         trans_axes = self.get_custom_axes(
-                            a=trans_center, b=[edges[1]], c=np.zeros(3)
+                            a=trans_center, b=[edges[0]], c=np.zeros(3)
                         )
 
             # look for heavy atoms in residue of interest

--- a/docs/science.rst
+++ b/docs/science.rst
@@ -70,9 +70,11 @@ The axes for this transformation are calculated for each bead in each time step.
 
 For the polymer level, the translational and rotational axes are defined as the principal axes of the molecule.
 
-For the residue level, there are two situations.
+For the residue level, there are three situations.
 When the residue is not bonded to any other residues, the translational and rotational axes are the principal axes of the molecule.
-When the residue is part of a larger polymer, the translational axes are the principal axes of the polymer, and the rotational axes are defined from the two heavy atoms bonded to neighbour residues(E1,E2) and the average position of all other backbone atoms in the residue (C). The backbone of a residue is defined as the shortest path between the two edge atoms of the residue, i.e. the two heavy atoms bonded to neighbour residues.The centre of rotation is located at the point where the perpendicular from C meets the E1-E2 vector.
+When the residue is part of a larger polymer and is not a terminus of that polymer, the translational axes are the principal axes of the polymer, and the rotational axes are defined from the two heavy atoms bonded to neighbour residues (E1,E2) and the average position of all other backbone atoms in the residue (C). The backbone of a residue is defined as the shortest path between the two edge atoms of the residue, i.e.the two heavy atoms bonded to neighbour residues.The centre of rotation (O) is located at the point where the perpendicular from C meets the E1-E2 vector.
+When the residue is part of a larger polymer and is a terminus of that polymer, the translational axes are the principal axes of the polymer, and the rotational axes are defined from the heavy atom bonded to a
+neighbour residue (E1), the average position of all heavy atoms bonded to E1 (C) and the average position of all other heavy atoms in the residue (E2). The centre of rotation (O) is defined the same as above forthe non-terminal residue case.
 
 For the united atom level, the translational axes are defined as the residue rotational axes and the rotational axes are defined from the average position of the bonds to neighbouring heavy atoms.
 If there are no bonds to other heavy atoms, the principal axes of the molecule are used.

--- a/tests/unit/CodeEntropy/levels/test_axes.py
+++ b/tests/unit/CodeEntropy/levels/test_axes.py
@@ -1269,7 +1269,7 @@ def test_get_residue_bonded_axes_1_heavy_atom_backbone_2neighbours(monkeypatch):
 
     u.atoms.select_atoms.side_effect = _select_atoms
     u.atoms.principal_axes.return_value = np.eye(3)
-    monkeypatch.setattr(ax, "get_chain", backbone_atom)
+    monkeypatch.setattr(ax, "get_chain", lambda residue, first, last: [backbone_atom])
     monkeypatch.setattr(
         ax,
         "get_custom_residue_moment_of_inertia",
@@ -1639,3 +1639,49 @@ def test_get_UA_axes_raises_when_only_rot_axes_fail(monkeypatch):
 
     with pytest.raises(ValueError):
         ax.get_UA_axes(u, index=0, res_position=None)
+
+
+def get_residue_bonded_axes_terminal_2_points(monkeypatch):
+    ax = AxesCalculator()
+    u = MagicMock()
+    u.dimensions = np.array([10.0, 10.0, 10.0, 90, 90, 90])
+    monkeypatch.setattr("CodeEntropy.levels.axes.make_whole", lambda _ag: None)
+    residue = u.select_atoms("resindex 0")
+    residue.__len__.return_value = 3
+    uas = _FakeAtomGroup(
+        [
+            _atom(index=0, mass=12.0, pos=[1, 0, 0]),
+            _atom(index=1, mass=12.0, pos=[0, 1, 0]),
+        ]
+    )
+
+    def _select_atoms(q):
+        if q == "mass 2 to 999":
+            return uas
+        if q.startswith("(mass 2 to 999) and bonded"):
+            # the bonded atom
+            return [uas[1]]
+        if q.startswith("resindex 0 and (bonded resindex"):
+            # edge atom
+            return [uas[2]]
+
+    u.atoms.principal_axes.return_value = np.eye(3)
+    u.atoms.select_atoms.side_effect = _select_atoms
+    residue.select_atoms.side_effect = _select_atoms
+
+    monkeypatch.setattr(
+        ax,
+        "get_custom_residue_moment_of_inertia",
+        lambda center_of_mass, positions, masses, custom_rot_axes, dimensions: np.array(
+            [1, 1, 1]
+        ),
+    )
+
+    trans_axes, rot_axes, rot_center, moi = ax.get_residue_axes(
+        u, index=0, relative_index=0
+    )
+
+    assert np.allclose(trans_axes, np.eye(3))
+    assert rot_axes.shape == (3, 3)
+    assert np.allclose(rot_center, [1, 1, 0])
+    assert np.allclose(moi, np.array([1, 1, 1]))

--- a/tests/unit/CodeEntropy/levels/test_axes.py
+++ b/tests/unit/CodeEntropy/levels/test_axes.py
@@ -1220,7 +1220,7 @@ def test_get_residue_axes_custom_path(monkeypatch):
 
     backbone_center = np.array([0.0, 1.0, 0.0])
     rot_center, rot_axes = ax.get_residue_custom_axes(
-        [edge_atoms[0], edge_atoms[1]], backbone_center
+        [edge_atoms[0].position, edge_atoms[1].position], backbone_center
     )
 
     assert rot_center.shape == (3,)
@@ -1337,34 +1337,33 @@ def test_get_residue_bonded_axes_multiple_heavy_atoms_backbone_2neighbours(monke
     assert np.allclose(moi, np.array([1, 1, 1]))
 
 
-def test_get_residue_bonded_axes_first_resid(monkeypatch):
+def test_get_residue_bonded_axes_terminal_resid(monkeypatch):
     ax = AxesCalculator()
     u = MagicMock()
     u.dimensions = np.array([10.0, 10.0, 10.0, 90, 90, 90])
     monkeypatch.setattr("CodeEntropy.levels.axes.make_whole", lambda _ag: None)
     residue = u.select_atoms("resindex 0")
     residue.__len__.return_value = 3
-    residue.atoms = _FakeAtomGroup(
+    uas = _FakeAtomGroup(
         [
             _atom(index=0, mass=12.0, pos=[1, 0, 0]),
             _atom(index=1, mass=12.0, pos=[0, 1, 0]),
             _atom(index=2, mass=12.0, pos=[0, 0, 0]),
         ]
     )
-    edge_atom_set = _FakeAtomGroup(
-        [
-            _atom(index=2, mass=12.0, pos=[0, 0, 0]),
-        ]
-    )
 
     def _select_atoms(q):
-        if q.endswith("(bonded resindex -1 or resindex 1)"):
-            return edge_atom_set
+        if q == "mass 2 to 999":
+            return uas
+        if q.startswith("(mass 2 to 999) and bonded"):
+            return [uas[1]]
+        if q.startswith("resindex 0 and (bonded resindex"):
+            return [uas[2]]
 
-    backbone_atom = residue.atoms[1]
     u.atoms.principal_axes.return_value = np.eye(3)
     u.atoms.select_atoms.side_effect = _select_atoms
-    monkeypatch.setattr(ax, "get_chain", backbone_atom)
+    residue.select_atoms.side_effect = _select_atoms
+
     monkeypatch.setattr(
         ax,
         "get_custom_residue_moment_of_inertia",
@@ -1377,63 +1376,6 @@ def test_get_residue_bonded_axes_first_resid(monkeypatch):
         u, index=0, relative_index=0
     )
 
-    assert len(edge_atom_set) == 1
-    assert np.allclose(trans_axes, np.eye(3))
-    assert rot_axes.shape == (3, 3)
-    assert rot_center.shape == (3,)
-    assert np.allclose(moi, np.array([1, 1, 1]))
-
-
-def test_get_residue_bonded_axes_last_resid(monkeypatch):
-    ax = AxesCalculator()
-    u = MagicMock()
-    u.dimensions = np.array([10.0, 10.0, 10.0, 90, 90, 90])
-    monkeypatch.setattr("CodeEntropy.levels.axes.make_whole", lambda _ag: None)
-    residue = u.select_atoms("resindex 2")
-    residue.__len__.return_value = 3
-    heavy_atoms = _FakeAtomGroup(
-        [
-            _atom(index=4, mass=12.0, pos=[1, 0, 0]),
-            _atom(index=5, mass=12.0, pos=[0, 1, 0]),
-            _atom(index=6, mass=12.0, pos=[0, 0, 0]),
-        ]
-    )
-    edge_atom_set = _FakeAtomGroup(
-        [
-            _atom(index=4, mass=12.0, pos=[0, 0, 0]),
-        ]
-    )
-
-    def _select_atoms(q):
-        if q == "mass 2 to 999":
-            # return heavy atoms group
-            return heavy_atoms
-        if q.endswith("(bonded resindex 1 or resindex 3)"):
-            return edge_atom_set
-        if q == ("(mass 2 to 999) and bonded index 6"):
-            return [heavy_atoms[1]]
-        if q == ("(mass 2 to 999) and bonded index 5"):
-            return [heavy_atoms[0], heavy_atoms[2]]
-
-    backbone_atom = heavy_atoms[1]
-    u.atoms.principal_axes.return_value = np.eye(3)
-    u.atoms.select_atoms.side_effect = _select_atoms
-    residue.select_atoms.side_effect = _select_atoms
-    residue.atoms.select_atoms.side_effect = _select_atoms
-    monkeypatch.setattr(ax, "get_chain", backbone_atom)
-    monkeypatch.setattr(
-        ax,
-        "get_custom_residue_moment_of_inertia",
-        lambda center_of_mass, positions, masses, custom_rot_axes, dimensions: np.array(
-            [1, 1, 1]
-        ),
-    )
-
-    trans_axes, rot_axes, rot_center, moi = ax.get_residue_axes(
-        u, index=2, relative_index=0
-    )
-
-    assert len(edge_atom_set) == 1
     assert np.allclose(trans_axes, np.eye(3))
     assert rot_axes.shape == (3, 3)
     assert rot_center.shape == (3,)
@@ -1473,8 +1415,10 @@ def test_get_ua_axes_bonded_axes_2neighbours_1_heavy_atom_backbone(monkeypatch):
             return [heavy_atoms[1]]
 
     residue_group.select_atoms.side_effect = _select_atoms
+    residue.select_atoms.side_effect = _select_atoms
     residue.atoms.select_atoms.side_effect = _select_atoms
-    monkeypatch.setattr(ax, "get_chain", lambda residue, first, last: heavy_atoms[1])
+
+    monkeypatch.setattr(ax, "get_chain", lambda residue, first, last: [heavy_atoms[1]])
     monkeypatch.setattr(
         ax,
         "get_bonded_axes",
@@ -1560,25 +1504,23 @@ def test_get_ua_axes_bonded_axes_first_resid(monkeypatch):
 
     residue.atoms[0] = heavy_atoms[0]
     residue.atoms[0].position = heavy_atoms[0].position
-    edge_atom_set = _FakeAtomGroup(
-        [
-            _atom(index=2, mass=12.0, pos=(0, 0, 1)),
-        ],
-    )
+    edge_atom_set = [heavy_atoms[2]]
+    bonded_atoms = [heavy_atoms[1]]
 
     def _select_atoms(q):
         if q == "mass 2 to 999":
             # return heavy atoms group
             return heavy_atoms
+        if q.startswith("index"):
+            return [heavy_atoms[0]]
         if q.startswith("resindex "):
             return edge_atom_set
-        if q.startswith("index "):
-            return [heavy_atoms[0]]
+        if q.startswith("(mass 2 to 999) and bonded index "):
+            return bonded_atoms
 
     residue_group.select_atoms.side_effect = _select_atoms
     residue.atoms.select_atoms.side_effect = _select_atoms
-    edge_atom_set.atoms = [edge_atom_set[0]]
-    monkeypatch.setattr(ax, "get_chain", lambda residue, first, last: heavy_atoms[1])
+
     monkeypatch.setattr(
         ax,
         "get_bonded_axes",
@@ -1598,7 +1540,7 @@ def test_get_ua_axes_bonded_axes_last_resid(monkeypatch):
     ax = AxesCalculator()
     residue_group = MagicMock()
     residue_group.__len__ = 2
-    residue = residue_group.residues[1]
+    residue = residue_group.residues[0]
     heavy_atoms = _FakeAtomGroup(
         [
             _atom(index=0, mass=12.0, pos=(1, 0, 0)),
@@ -1607,29 +1549,25 @@ def test_get_ua_axes_bonded_axes_last_resid(monkeypatch):
         ],
     )
 
-    edge_atom_set = _FakeAtomGroup(
-        [
-            _atom(index=0, mass=12.0, pos=(1, 0, 0)),
-        ],
-    )
+    residue.atoms[0] = heavy_atoms[0]
+    residue.atoms[0].position = heavy_atoms[0].position
+    edge_atom_set = [heavy_atoms[0]]
+    bonded_atoms = [heavy_atoms[1]]
 
     def _select_atoms(q):
         if q == "mass 2 to 999":
             # return heavy atoms group
             return heavy_atoms
+        if q.startswith("index"):
+            return [heavy_atoms[0]]
         if q.startswith("resindex "):
             return edge_atom_set
-        if q.startswith("index "):
-            return [heavy_atoms[0]]
-        if q == ("(mass 2 to 999) and bonded index 2"):
-            return [heavy_atoms[1]]
-        if q == ("(mass 2 to 999) and bonded index 1"):
-            return [heavy_atoms[0], heavy_atoms[2]]
+        if q.startswith("(mass 2 to 999) and bonded index "):
+            return bonded_atoms
 
     residue_group.select_atoms.side_effect = _select_atoms
     residue.atoms.select_atoms.side_effect = _select_atoms
-    edge_atom_set.atoms = [edge_atom_set[0]]
-    monkeypatch.setattr(ax, "get_chain", lambda residue, first, last: heavy_atoms[1])
+
     monkeypatch.setattr(
         ax,
         "get_bonded_axes",

--- a/tests/unit/CodeEntropy/levels/test_axes.py
+++ b/tests/unit/CodeEntropy/levels/test_axes.py
@@ -1641,34 +1641,118 @@ def test_get_UA_axes_raises_when_only_rot_axes_fail(monkeypatch):
         ax.get_UA_axes(u, index=0, res_position=None)
 
 
-def get_residue_bonded_axes_terminal_2_points(monkeypatch):
+def test_get_ua_axes_bonded_terminal_2_points(monkeypatch):
+    ax = AxesCalculator()
+    residue_group = MagicMock()
+    residue_group.__len__ = 2
+    residue = residue_group.residues[1]
+    heavy_atoms = _FakeAtomGroup(
+        [
+            _atom(index=0, mass=12.0, pos=(1, 0, 0)),
+            _atom(index=1, mass=12.0, pos=(0, 1, 0)),
+        ],
+    )
+    edge_atom_set = [heavy_atoms[0]]
+    bonded_atoms = [heavy_atoms[1]]
+
+    def _select_atoms(q):
+        if q == "mass 2 to 999":
+            # return heavy atoms group
+            return heavy_atoms
+        if q.startswith("index"):
+            return [heavy_atoms[0]]
+        if q.startswith("resindex "):
+            return edge_atom_set
+        if q.startswith("(mass 2 to 999) and bonded index "):
+            return bonded_atoms
+
+    residue_group.select_atoms.side_effect = _select_atoms
+    residue.atoms.select_atoms.side_effect = _select_atoms
+
+    monkeypatch.setattr(
+        ax,
+        "get_bonded_axes",
+        lambda system, atom, dimensions: (np.eye(3), np.array([1.0, 1.0, 1.0])),
+    )
+
+    monkeypatch.setattr(ax, "get_custom_axes", lambda a, b, c: 2 * np.eye(3))
+
+    trans_axes, rot_axes, rot_center, moi = ax.get_UA_axes(
+        data_container=residue_group, index=0, res_position=1
+    )
+
+    assert np.allclose(trans_axes, 2 * np.eye(3))
+    assert np.allclose(rot_axes, np.eye(3))
+    assert np.allclose(rot_center, [1, 0, 0])
+    assert np.allclose(moi, np.array([1, 1, 1]))
+
+
+def test_get_ua_axes_non_terminal_2_atoms(monkeypatch):
+    ax = AxesCalculator()
+    residue_group = MagicMock()
+    residue_group.__len__ = 3
+    residue = residue_group.residues[1]
+    heavy_atoms = _FakeAtomGroup(
+        [
+            _atom(index=0, mass=12.0, pos=(1, 1, 1)),
+            _atom(index=1, mass=12.0, pos=(3, 3, 3)),
+        ],
+    )
+
+    def _select_atoms(q):
+        if q == "mass 2 to 999":
+            # return heavy atoms group
+            return heavy_atoms
+        if q.startswith("index"):
+            return [heavy_atoms[0]]
+        if q.startswith("resindex "):
+            return heavy_atoms
+
+    residue_group.select_atoms.side_effect = _select_atoms
+    residue.atoms.select_atoms.side_effect = _select_atoms
+    monkeypatch.setattr(
+        ax,
+        "get_bonded_axes",
+        lambda system, atom, dimensions: (np.eye(3), 3 * np.eye(3)),
+    )
+    monkeypatch.setattr(ax, "get_custom_axes", lambda a, b, c: 2 * np.eye(3))
+    monkeypatch.setattr(ax, "get_chain", lambda residue, first, last: [])
+    trans_axes, rot_axes, rot_center, moi = ax.get_UA_axes(
+        data_container=residue_group, index=0, res_position=0
+    )
+
+    assert np.allclose(trans_axes, 2 * np.eye(3))
+    assert np.allclose(rot_axes, np.eye(3))
+    assert np.allclose(rot_center, [1, 1, 1])
+    assert np.allclose(moi, 3 * np.eye(3))
+
+
+def test_get_residue_axes_non_terminal_2_atoms(monkeypatch):
     ax = AxesCalculator()
     u = MagicMock()
     u.dimensions = np.array([10.0, 10.0, 10.0, 90, 90, 90])
     monkeypatch.setattr("CodeEntropy.levels.axes.make_whole", lambda _ag: None)
-    residue = u.select_atoms("resindex 0")
-    residue.__len__.return_value = 3
+    residue = u.select_atoms("resindex 5")
+    residue.__len__.return_value = 2
+    print(f"The residue should be: {residue}")
+    u.atoms.principal_axes.return_value = np.eye(3)
     uas = _FakeAtomGroup(
         [
-            _atom(index=0, mass=12.0, pos=[1, 0, 0]),
-            _atom(index=1, mass=12.0, pos=[0, 1, 0]),
-        ]
+            _atom(index=0, mass=12.0, pos=(1, 1, 1)),
+            _atom(index=1, mass=12.0, pos=(3, 3, 3)),
+        ],
     )
 
     def _select_atoms(q):
         if q == "mass 2 to 999":
             return uas
-        if q.startswith("(mass 2 to 999) and bonded"):
-            # the bonded atom
-            return [uas[1]]
-        if q.startswith("resindex 0 and (bonded resindex"):
-            # edge atom
-            return [uas[2]]
+        if q.startswith("resindex 5 and (bonded resindex"):
+            return uas
 
-    u.atoms.principal_axes.return_value = np.eye(3)
     u.atoms.select_atoms.side_effect = _select_atoms
-    residue.select_atoms.side_effect = _select_atoms
-
+    residue.select_atoms.side_effect = residue
+    monkeypatch.setattr(ax, "get_chain", lambda residue, first, last: [])
+    monkeypatch.setattr(ax, "get_custom_axes", lambda a, b, c: 2 * np.eye(3))
     monkeypatch.setattr(
         ax,
         "get_custom_residue_moment_of_inertia",
@@ -1678,10 +1762,58 @@ def get_residue_bonded_axes_terminal_2_points(monkeypatch):
     )
 
     trans_axes, rot_axes, rot_center, moi = ax.get_residue_axes(
-        u, index=0, relative_index=0
+        data_container=u,
+        index=5,
+        relative_index=0,
     )
 
     assert np.allclose(trans_axes, np.eye(3))
-    assert rot_axes.shape == (3, 3)
-    assert np.allclose(rot_center, [1, 1, 0])
-    assert np.allclose(moi, np.array([1, 1, 1]))
+    assert np.allclose(rot_axes, 2 * np.eye(3))
+    assert np.allclose(rot_center, [2, 2, 2])
+    assert np.allclose(moi, [1, 1, 1])
+
+
+def test_get_residue_axes_terminal_2_atoms(monkeypatch):
+    ax = AxesCalculator()
+    u = MagicMock()
+    u.dimensions = np.array([10.0, 10.0, 10.0, 90, 90, 90])
+    monkeypatch.setattr("CodeEntropy.levels.axes.make_whole", lambda _ag: None)
+    residue = u.select_atoms("resindex 0")
+    residue.__len__.return_value = 3
+    uas = _FakeAtomGroup(
+        [
+            _atom(index=0, mass=12.0, pos=(1, 0, 0)),
+            _atom(index=1, mass=12.0, pos=(0, 1, 0)),
+            _atom(index=2, mass=12.0, pos=(0, 0, 1)),
+        ],
+    )
+    u.atoms.principal_axes.return_value = np.eye(3)
+
+    def _select_atoms(q):
+        if q == "mass 2 to 999":
+            return uas
+        if q.startswith("resindex 0 and (bonded resindex"):
+            # the edge atom
+            return [uas[2]]
+        if q.startswith("(mass 2 to 999) and bonded index "):
+            return uas[0:2]
+
+    u.atoms.select_atoms.side_effect = _select_atoms
+    residue.select_atoms.side_effect = _select_atoms
+    monkeypatch.setattr(ax, "get_custom_axes", lambda a, b, c: 2 * np.eye(3))
+    monkeypatch.setattr(
+        ax,
+        "get_custom_residue_moment_of_inertia",
+        lambda center_of_mass, positions, masses, custom_rot_axes, dimensions: np.array(
+            [1, 1, 1]
+        ),
+    )
+    trans_axes, rot_axes, rot_center, moi = ax.get_residue_axes(
+        data_container=u,
+        index=0,
+        relative_index=0,
+    )
+    assert np.allclose(trans_axes, np.eye(3))
+    assert np.allclose(rot_axes, 2 * np.eye(3))
+    assert np.allclose(rot_center, [0, 0, 1])
+    assert np.allclose(moi, [1, 1, 1])

--- a/tests/unit/CodeEntropy/levels/test_axes.py
+++ b/tests/unit/CodeEntropy/levels/test_axes.py
@@ -218,6 +218,7 @@ def test_get_UA_axes_raises_when_bonded_axes_fail(monkeypatch):
         return []
 
     u.select_atoms.side_effect = _sel
+
     monkeypatch.setattr("CodeEntropy.levels.axes.make_whole", lambda _ag: None)
     monkeypatch.setattr(ax, "get_bonded_axes", lambda **kwargs: (None, None))
 
@@ -1623,21 +1624,21 @@ def test_get_UA_axes_raises_when_only_rot_axes_fail(monkeypatch):
     u = MagicMock()
     u.atoms.principal_axes.return_value = np.eye(3)
     u.dimensions = np.array([10.0, 10.0, 10.0, 90, 90, 90])
-    residue = MagicMock()
-    u.residues = [residue]
-    heavy_atoms = _FakeAtomGroup(
-        [
-            _atom(index=0, mass=12.0, pos=(1, 0, 0)),
-            _atom(index=1, mass=12.0, pos=(0, 1, 0)),
-        ],
-    )
+    heavy_atoms = [
+        _atom(index=0, mass=12.0, pos=(1, 0, 0)),
+        _atom(index=1, mass=12.0, pos=(0, 1, 0)),
+    ]
+    u.residues = [heavy_atoms]
 
     def _sel(q):
         if q == "mass 2 to 999":
-            return [heavy_atoms]
+            return heavy_atoms
+        if q.startswith("index"):
+            return [heavy_atoms[0]]
 
     u.select_atoms.side_effect = _sel
-    residue.atoms.select_atoms.side_effect = _sel
+    u.atoms.select_atoms.side_effect = _sel
+
     monkeypatch.setattr("CodeEntropy.levels.axes.make_whole", lambda _ag: None)
     monkeypatch.setattr(ax, "get_bonded_axes", lambda **kwargs: (None, None))
 
@@ -1738,7 +1739,6 @@ def test_get_residue_axes_non_terminal_2_atoms(monkeypatch):
     monkeypatch.setattr("CodeEntropy.levels.axes.make_whole", lambda _ag: None)
     residue = u.select_atoms("resindex 5")
     residue.__len__.return_value = 2
-    print(f"The residue should be: {residue}")
     u.atoms.principal_axes.return_value = np.eye(3)
     uas = _FakeAtomGroup(
         [

--- a/tests/unit/CodeEntropy/levels/test_axes.py
+++ b/tests/unit/CodeEntropy/levels/test_axes.py
@@ -1363,6 +1363,7 @@ def test_get_residue_bonded_axes_terminal_resid(monkeypatch):
     u.atoms.principal_axes.return_value = np.eye(3)
     u.atoms.select_atoms.side_effect = _select_atoms
     residue.select_atoms.side_effect = _select_atoms
+    residue.atoms.select_atoms.side_effect = _select_atoms
 
     monkeypatch.setattr(
         ax,
@@ -1624,16 +1625,19 @@ def test_get_UA_axes_raises_when_only_rot_axes_fail(monkeypatch):
     u.dimensions = np.array([10.0, 10.0, 10.0, 90, 90, 90])
     residue = MagicMock()
     u.residues = [residue]
-    heavy_atoms = [
-        _atom(index=0, mass=12.0, pos=(1, 0, 0)),
-        _atom(index=1, mass=12.0, pos=(0, 1, 0)),
-    ]
+    heavy_atoms = _FakeAtomGroup(
+        [
+            _atom(index=0, mass=12.0, pos=(1, 0, 0)),
+            _atom(index=1, mass=12.0, pos=(0, 1, 0)),
+        ],
+    )
 
     def _sel(q):
         if q == "mass 2 to 999":
-            return heavy_atoms
+            return [heavy_atoms]
 
     u.select_atoms.side_effect = _sel
+    residue.atoms.select_atoms.side_effect = _sel
     monkeypatch.setattr("CodeEntropy.levels.axes.make_whole", lambda _ag: None)
     monkeypatch.setattr(ax, "get_bonded_axes", lambda **kwargs: (None, None))
 
@@ -1779,7 +1783,7 @@ def test_get_residue_axes_terminal_2_atoms(monkeypatch):
     u.dimensions = np.array([10.0, 10.0, 10.0, 90, 90, 90])
     monkeypatch.setattr("CodeEntropy.levels.axes.make_whole", lambda _ag: None)
     residue = u.select_atoms("resindex 0")
-    residue.__len__.return_value = 3
+    residue.__len__.return_value = 2
     uas = _FakeAtomGroup(
         [
             _atom(index=0, mass=12.0, pos=(1, 0, 0)),
@@ -1800,6 +1804,7 @@ def test_get_residue_axes_terminal_2_atoms(monkeypatch):
 
     u.atoms.select_atoms.side_effect = _select_atoms
     residue.select_atoms.side_effect = _select_atoms
+    residue.atoms.select_atoms.side_effect = _select_atoms
     monkeypatch.setattr(ax, "get_custom_axes", lambda a, b, c: 2 * np.eye(3))
     monkeypatch.setattr(
         ax,
@@ -1817,3 +1822,221 @@ def test_get_residue_axes_terminal_2_atoms(monkeypatch):
     assert np.allclose(rot_axes, 2 * np.eye(3))
     assert np.allclose(rot_center, [0, 0, 1])
     assert np.allclose(moi, [1, 1, 1])
+
+
+def test_get_res_axes_terminal_1_atom(monkeypatch):
+    ax = AxesCalculator()
+    u = MagicMock()
+    u.dimensions = np.array([10.0, 10.0, 10.0, 90, 90, 90])
+    monkeypatch.setattr("CodeEntropy.levels.axes.make_whole", lambda _ag: None)
+    residue = u.select_atoms("resindex 0")
+    residue.__len__.return_value = 1
+    uas = _FakeAtomGroup(
+        [
+            _atom(index=0, mass=12.0, pos=(1, 0, 0)),
+        ],
+    )
+    u.atoms.principal_axes.return_value = np.eye(3)
+    residue.atoms.principal_axes.return_value = np.eye(3)
+
+    def _select_atoms(q):
+        if q == "mass 2 to 999":
+            return uas
+        if q.startswith("(mass 2 to 999) and bonded index "):
+            return []
+        if q.startswith("resindex "):
+            return [uas[0]]
+
+    u.atoms.select_atoms.side_effect = _select_atoms
+    residue.select_atoms.side_effect = _select_atoms
+    residue.atoms.select_atoms.side_effect = _select_atoms
+
+    monkeypatch.setattr(
+        ax,
+        "get_custom_residue_moment_of_inertia",
+        lambda center_of_mass, positions, masses, custom_rot_axes, dimensions: np.array(
+            [1, 1, 1]
+        ),
+    )
+    trans_axes, rot_axes, rot_center, moi = ax.get_residue_axes(
+        data_container=u,
+        index=0,
+        relative_index=0,
+    )
+    assert np.allclose(trans_axes, np.eye(3))
+    assert np.allclose(rot_axes, np.eye(3))
+    assert np.allclose(rot_center, [1, 0, 0])
+    assert np.allclose(moi, [1, 1, 1])
+
+
+def test_get_UA_axes_terminal_1_atom(monkeypatch):
+    ax = AxesCalculator()
+    residue_group = MagicMock()
+    residue_group.__len__ = 2
+    residue = residue_group.residues[1]
+    heavy_atoms = _FakeAtomGroup(
+        [
+            _atom(index=0, mass=12.0, pos=(1, 1, 1)),
+            _atom(index=1, mass=12.0, pos=(3, 3, 3)),
+        ],
+    )
+
+    def _select_atoms_data_container(q):
+        if q == "mass 2 to 999":
+            # return heavy atoms group
+            return heavy_atoms
+        if q.startswith("resindex "):
+            return [heavy_atoms[0]]
+
+    def _select_atoms_residue(q):
+        if q == "mass 2 to 999":
+            # return heavy atoms group
+            return [heavy_atoms[0]]
+        if q.startswith("index"):
+            return [heavy_atoms[0]]
+        if q.startswith("(mass 2 to 999) and bonded "):
+            return []
+
+    residue_group.select_atoms.side_effect = _select_atoms_data_container
+    residue_group.atoms.select_atoms.side_effect = _select_atoms_data_container
+    residue.select_atoms.side_effect = _select_atoms_residue
+    residue.atoms.select_atoms.side_effect = _select_atoms_residue
+    monkeypatch.setattr(
+        ax,
+        "get_bonded_axes",
+        lambda system, atom, dimensions: (np.eye(3), 3 * np.eye(3)),
+    )
+    residue.atoms.principal_axes.return_value = 2 * np.eye(3)
+
+    trans_axes, rot_axes, rot_center, moi = ax.get_UA_axes(
+        data_container=residue_group, index=0, res_position=-1
+    )
+
+    assert np.allclose(trans_axes, 2 * np.eye(3))
+    assert np.allclose(rot_axes, np.eye(3))
+    assert np.allclose(rot_center, [1, 1, 1])
+    assert np.allclose(moi, 3 * np.eye(3))
+
+
+def test_get_terminal_axes_1point(monkeypatch):
+    ax = AxesCalculator()
+    residue = MagicMock()
+    residue.__len__ = 1
+    heavy_atoms = _FakeAtomGroup(
+        [
+            _atom(index=0, mass=12.0, pos=(1, 0, 0)),
+        ],
+    )
+
+    def _select_atoms(q):
+        if q == "mass 2 to 999":
+            return heavy_atoms
+        if q.startswith("(mass 2 to 999) and bonded"):
+            return []
+
+    residue.atoms.select_atoms.side_effect = _select_atoms
+    residue.atoms.principal_axes.return_value = np.eye(3)
+    centre, axes = ax.get_terminal_axes(residue, heavy_atoms[0])
+    assert np.allclose(centre, [1, 0, 0])
+    assert np.allclose(axes, np.eye(3))
+
+
+def test_get_terminal_axes_2points(monkeypatch):
+    ax = AxesCalculator()
+    residue = MagicMock()
+    residue.__len__ = 2
+    heavy_atoms = _FakeAtomGroup(
+        [
+            _atom(index=0, mass=12.0, pos=(1, 0, 0)),
+            _atom(index=1, mass=12.0, pos=(0, 1, 0)),
+        ],
+    )
+
+    def _select_atoms(q):
+        if q == "mass 2 to 999":
+            return heavy_atoms
+        if q.startswith("(mass 2 to 999) and bonded"):
+            return [heavy_atoms[1]]
+
+    residue.atoms.select_atoms.side_effect = _select_atoms
+    monkeypatch.setattr(ax, "get_custom_axes", lambda a, b, c: 2 * np.eye(3))
+    centre, axes = ax.get_terminal_axes(residue, heavy_atoms[0])
+    assert np.allclose(centre, [1, 0, 0])
+    assert np.allclose(axes, 2 * np.eye(3))
+
+
+def test_get_terminal_axes_3points(monkeypatch):
+    ax = AxesCalculator()
+    residue = MagicMock()
+    residue.__len__ = 4
+    heavy_atoms = _FakeAtomGroup(
+        [
+            _atom(index=0, mass=12.0, pos=(0, 0, 0)),
+            _atom(index=1, mass=12.0, pos=(1, 1, 0)),
+            _atom(index=2, mass=12.0, pos=(1, 0, 0)),
+            _atom(index=3, mass=14.0, pos=(3, 0, 0)),
+        ],
+    )
+
+    def _select_atoms(q):
+        if q == "mass 2 to 999":
+            return heavy_atoms
+        if q.startswith("(mass 2 to 999) and bonded"):
+            return [heavy_atoms[1]]
+
+    residue.atoms.select_atoms.side_effect = _select_atoms
+    monkeypatch.setattr(
+        ax, "get_residue_custom_axes", lambda edges, center: ([1, 0, 0], 3 * np.eye(3))
+    )
+
+    centre, axes = ax.get_terminal_axes(residue, heavy_atoms[0])
+
+    assert np.allclose(centre, [1, 0, 0])
+    assert np.allclose(axes, 3 * np.eye(3))
+
+
+def test_get_non_terminal_axes_2points(monkeypatch):
+    ax = AxesCalculator()
+    residue = MagicMock()
+    residue.__len__ = 2
+    heavy_atoms = _FakeAtomGroup(
+        [
+            _atom(index=0, mass=12.0, pos=(2, 0, 0)),
+            _atom(index=1, mass=12.0, pos=(0, 2, 0)),
+        ],
+    )
+    monkeypatch.setattr(ax, "get_chain", lambda residue, first, last: [])
+    monkeypatch.setattr(ax, "get_custom_axes", lambda a, b, c: 2 * np.eye(3))
+    centre, axes = ax.get_non_terminal_axes(residue, heavy_atoms)
+    assert np.allclose(centre, [1, 1, 0])
+    assert np.allclose(axes, 2 * np.eye(3))
+
+
+def test_get_non_terminal_axes_3points(monkeypatch):
+    ax = AxesCalculator()
+    residue = MagicMock()
+    residue.__len__ = 4
+    heavy_atoms = _FakeAtomGroup(
+        [
+            _atom(index=0, mass=12.0, pos=(0, 0, 0)),
+            _atom(index=1, mass=12.0, pos=(1, 0, 0)),
+            _atom(index=2, mass=14.0, pos=(3, 0, 0)),
+            _atom(index=3, mass=12.0, pos=(1, 1, 0)),
+        ],
+    )
+    edges = _FakeAtomGroup(
+        [
+            _atom(index=0, mass=12.0, pos=(0, 0, 0)),
+            _atom(index=3, mass=12.0, pos=(1, 1, 0)),
+        ],
+    )
+    monkeypatch.setattr(
+        ax, "get_chain", lambda residue, first, last: [heavy_atoms[1], heavy_atoms[2]]
+    )
+    monkeypatch.setattr(
+        ax, "get_residue_custom_axes", lambda edges, center: ([1, 0, 0], 3 * np.eye(3))
+    )
+    centre, axes = ax.get_non_terminal_axes(residue, edges)
+
+    assert np.allclose(centre, [1, 0, 0])
+    assert np.allclose(axes, 3 * np.eye(3))


### PR DESCRIPTION
## Summary
Terminal residue axes are no longer dependent on atom indices. The edge atom (i.e. heavy atom bonded to neighbour residue) is chosen alongside the average position of heavy atoms bonded to the edge atom and average position of all other heavy in the residue as the three points used for determining the axes. The centre of rotation (at res level)/translation (at UA level) and axes are then computed from the three points similar to the case of non-terminal residues. 

## Changes

### Terminal residue treatment was changed
- Residue rotation and UA translation axes for terminal residues no longer use atom indices to emulate the backbone for non-terminal residues.
- The edge atom (E1 - red), defined as the heavy atom bonded to a neighbour residue is identified. All heavy atoms bonded to the edge atom (purple) are identified and their average position (C) is used as the third point for obtaining the centre of rotation. All other heavy atoms in the residue (green) are identified and used as the equivalent to the second edge(E2).
 
<img width="991" height="394" alt="image" src="https://github.com/user-attachments/assets/c98b1614-4a08-4033-abb5-7988e6207fca" />

- The centre of rotation (O - blue) is the point where the perpendicular from the C (purple)  meets the E1 (red)-E2 (green) vector.
- x-axis is along the centre of rotation (O) - first edge(E1) vector
- y axis is along the centre of rotation (O) - average position of bonded atoms (C) vector
- z-axis is perpendicular to the two 


### Edge cases have been introduced
- If there are no other heavy atoms in a terminal residue, other than the edge atom and those bonded to the edge atom, the centre of rotation is the edge atom and axes are defined as: x-axis is along the edge-bonded vector, y axis is an arbitrary perpendicular axis and z-axis is perpendicular to the two. (This uses the get_custom_axes function and is the same as case2 in get_bonded_axes for UAs)
- If the two edge atoms in a non-terminal residue are bonded (there is no backbone atom between them), the centre of rotation is located at their average position and axes are defined as: x-axis is along the centre-of-rotation-first edge vector, y-axis is arbitrary perpendicular and z-axis is perpendicular to the two.

### Tests for terminal residues and edge cases 
- Unit tests for terminal residues have been updated to reflect changes.
- New tests for the edge cases covered have been introduced

### Documentation
- Vibrational entropy in theory section of the documentation was modified to reflect changes.  

### get_residue_axes and get_UA_axes structure change
- New functions get_terminal_axes and get_non_terminal_axes are introduced and called in get_residue_axes and get_UA_axes to improve code flow.

## Impact
- This closes issue #399.
- Terminal residue treatment is no longer dependent on atom indexing, which is arbitrary. The same result would be obtained using topologies of the same molecule with different indexes.
- Residue rovibrational results are now slightly higher compared to total entropy results obtained using the index-based backbone. No signficant difference observed for UA transvibrational results. (only treatment of terminal residues differs in table below)
<img width="567" height="182" alt="image" src="https://github.com/user-attachments/assets/9074ed40-f03a-42cb-86ab-7dbd4828c05b" />
